### PR TITLE
Fix step logger output

### DIFF
--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/logging/JsonStepLogger.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/logging/JsonStepLogger.java
@@ -84,7 +84,7 @@ public class JsonStepLogger implements StepLogger {
             generator.writeStartObject();
             generator.writeFieldName("steps");
             generator.writeStartArray();
-            flush();
+            // don't flush now, lazily wait for a logged item
         } catch (IOException e) {
             //
         }

--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/AbstractBaseStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/AbstractBaseStep.java
@@ -110,7 +110,9 @@ public abstract class AbstractBaseStep<M extends BaseStepData, R> implements Bas
     @Override
     public ResultStatusObject execute(Map<String, Object> context) throws Exception {
         StepLogger stepLogger = stepLoggerFactory.createStepLogger();
+        stepLogger.start();
         JSONObject jsonObject = execute(stepLogger, context);
+        stepLogger.close();
         if (jsonObject == null) {
             return null;
         } else {

--- a/powerauth-java-cmd/src/main/java/io/getlime/security/powerauth/app/cmd/Application.java
+++ b/powerauth-java-cmd/src/main/java/io/getlime/security/powerauth/app/cmd/Application.java
@@ -262,13 +262,7 @@ public class Application {
                 case ACTIVATION_CREATE:
                 case ACTIVATION_PREPARE: {
                     if (powerAuthStep.equals(PowerAuthStep.ACTIVATION_PREPARE)) {
-                        stepLogger.writeItem(
-                                "generic-warning-deprecated",
-                                "Deprecated method",
-                                "Use 'create' method instead of deprecated 'prepare'",
-                                "WARNING",
-                                null
-                        );
+                        System.err.println("The 'prepare' step name is deprecated, use the 'create' step name instead");
                         powerAuthStep = PowerAuthStep.ACTIVATION_CREATE;
                     }
 


### PR DESCRIPTION
- Wait for a log item before flushing the step logger start messages
- Start and close step logger in the execute method