### PR TITLE
Fix #217: Improve logging of custom object into GetStatusStep

### DIFF
--- a/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v3/GetStatusStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/io/getlime/security/powerauth/lib/cmd/steps/v3/GetStatusStep.java
@@ -141,7 +141,7 @@ public class GetStatusStep extends AbstractBaseStep<GetStatusStepModel, ObjectRe
         final ActivationStatusResponse responseObject = stepContext.getResponseContext().getResponseBodyObject().getResponseObject();
         final byte[] cStatusBlob = BaseEncoding.base64().decode(responseObject.getEncryptedStatusBlob());
         final byte[] cStatusBlobNonce = useChallenge ? BaseEncoding.base64().decode(responseObject.getNonce()) : null;
-
+        final Map<String, Object> customObject = responseObject.getCustomObject();
         byte[] challenge = (byte[]) stepContext.getAttributes().get(ATTRIBUTE_CHALLENGE);
 
         final ActivationStatusBlobInfo statusBlobRaw = ACTIVATION.getStatusFromEncryptedBlob(cStatusBlob, challenge, cStatusBlobNonce, resultStatusObject.getTransportMasterKeyObject());
@@ -150,6 +150,7 @@ public class GetStatusStep extends AbstractBaseStep<GetStatusStepModel, ObjectRe
         final Map<String, Object> objectMap = new HashMap<>();
         objectMap.put("activationId", resultStatusObject.getActivationId());
         objectMap.put("statusBlob", statusBlob);
+        objectMap.put("customObject", customObject);
 
         stepContext.getStepLogger().writeItem(
                 getStep().id() + "-obtained",


### PR DESCRIPTION
This pull request adds logging of custom object in `GetStatusStep`, because this object became a bit more important due to onboarding process which uses it for obtaining activation flags.