### PR TITLE
Fix #559: Switch algorithm HS256 to HS384 for temporary keys

### DIFF
--- a/powerauth-java-cmd-lib/src/main/java/com/wultra/security/powerauth/lib/cmd/util/TemporaryKeyUtil.java
+++ b/powerauth-java-cmd-lib/src/main/java/com/wultra/security/powerauth/lib/cmd/util/TemporaryKeyUtil.java
@@ -237,12 +237,12 @@ public class TemporaryKeyUtil {
     }
 
     private static String signJwt(JWTClaimsSet jwtClaims, byte[] secretKey) throws Exception {
-        final JWSHeader jwsHeader = new JWSHeader(JWSAlgorithm.HS256);
+        final JWSHeader jwsHeader = new JWSHeader(JWSAlgorithm.HS384);
         final byte[] payloadBytes = jwtClaims.toPayload().toBytes();
         final Base64URL encodedHeader = jwsHeader.toBase64URL();
         final Base64URL encodedPayload = Base64URL.encode(payloadBytes);
         final String signingInput = encodedHeader + "." + encodedPayload;
-        final byte[] hash = new HMACHashUtilities().hash(secretKey, signingInput.getBytes(StandardCharsets.UTF_8));
+        final byte[] hash = new HMACHashUtilities().hash384(secretKey, signingInput.getBytes(StandardCharsets.UTF_8));
         final Base64URL signature = Base64URL.encode(hash);
         return encodedHeader + "." + encodedPayload + "." + signature;
     }


### PR DESCRIPTION
Switched JWT signing from `HS256` to `HS384` for temporary keys.