### PR TITLE
Fix #577: Create new step for signing with device private key

### DIFF
--- a/docs/Readme.md
+++ b/docs/Readme.md
@@ -201,6 +201,27 @@ Uses the `unlock` method to unlock the secure vault for an activation with activ
 
 _Note: If a `--password` option is not provided, this method requires interactive console input of the password, in order to unlock the knowledge related signature key._
 
+### Sign Data Using Asymmetric Algorithm
+
+Use this method to test obtaining the device private key and signing the data.
+
+```bash
+java -jar powerauth-java-cmd.jar \
+    --url "http://localhost:8080/enrollment-server" \
+    --status-file "/tmp/pa_status.json" \
+    --config-file "/tmp/pamk.json" \
+    --method "sign-asymmetric" \
+    --signature-type "possession_knowledge" \
+    --password "1234" \
+    --data-file "/tmp/request.json"
+```
+
+Uses the `sign-asymmetric` method to unlock the secure vault for an activation with activation ID stored in the status file `/tmp/pa_status.json`, by calling the PowerAuth Standard RESTful API endpoint `/pa/v3/vault/unlock` hosted on root URL `http://localhost:8080/enrollment-server`. Uses the master public key and application identifiers stored in the `/tmp/pamk.json` file. Unlocks the knowledge related signing key using `1234` as a password. The reason why vault is being unlocked is `SIGN_DATA`. The key identifier used for unlocking the vault is `KEK_DEVICE_PRIVATE`. 
+
+The unlocked device private key is then used for signing data using an asymmetric data signature algorithm. The asymmetric signature algorithm depends on the cryptography version.
+
+_Note: If a `--password` option is not provided, this method requires interactive console input of the password, in order to unlock the knowledge related signature key._
+
 ### Create Token
 
 Create a static token which can be used for repeated requests to data resources which support token based authentication.

--- a/powerauth-java-cmd-lib/src/main/java/com/wultra/security/powerauth/lib/cmd/consts/PowerAuthStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/com/wultra/security/powerauth/lib/cmd/consts/PowerAuthStep.java
@@ -94,6 +94,11 @@ public enum PowerAuthStep {
     SIGN_ENCRYPT("sign-encrypt", "Sign and Encrypt Request", "sign-encrypt"),
 
     /**
+     * Unlock device private keys and sign data
+     */
+    SIGN_ASYMMETRIC("sign-asymmetric", "Sign Data Using Private Key", "sign-asymmetric"),
+
+    /**
      * Creating new token
      */
     TOKEN_CREATE("token-create", "Token Create", "create-token"),

--- a/powerauth-java-cmd-lib/src/main/java/com/wultra/security/powerauth/lib/cmd/steps/GetStatusStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/com/wultra/security/powerauth/lib/cmd/steps/GetStatusStep.java
@@ -45,10 +45,7 @@ import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.Base64;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 /**
  * Helper class with step for getting activation status.
@@ -221,7 +218,7 @@ public class GetStatusStep extends AbstractBaseStep<GetStatusStepModel, Object> 
         }
 
 
-        final Map<String, Object> objectMap = new HashMap<>();
+        final Map<String, Object> objectMap = new LinkedHashMap<>();
         objectMap.put("activationId", resultStatusObject.getActivationId());
         objectMap.put("statusBlob", statusBlobInfo);
         objectMap.put("customObject", customObject);

--- a/powerauth-java-cmd-lib/src/main/java/com/wultra/security/powerauth/lib/cmd/steps/PrepareActivationStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/com/wultra/security/powerauth/lib/cmd/steps/PrepareActivationStep.java
@@ -36,6 +36,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -102,7 +103,7 @@ public class PrepareActivationStep extends AbstractActivationStep<PrepareActivat
         }
         final String activationCode = model.getActivationCode();
 
-        final Map<String, Object> objectMap = new HashMap<>();
+        final Map<String, Object> objectMap = new LinkedHashMap<>();
         objectMap.put("activationCode", activationCode);
         stepLogger.writeItem(
                 getStep().id() + "-activation-code",

--- a/powerauth-java-cmd-lib/src/main/java/com/wultra/security/powerauth/lib/cmd/steps/RemoveActivationStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/com/wultra/security/powerauth/lib/cmd/steps/RemoveActivationStep.java
@@ -32,7 +32,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.stereotype.Component;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -112,7 +112,7 @@ public class RemoveActivationStep extends AbstractBaseStep<RemoveStepModel, Obje
     @Override
     public void processResponse(StepContext<RemoveStepModel, ObjectResponse<ActivationRemoveResponse>> stepContext) {
         final String activationId = stepContext.getModel().getResultStatus().getActivationId();
-        final Map<String, Object> objectMap = new HashMap<>();
+        final Map<String, Object> objectMap = new LinkedHashMap<>();
         objectMap.put("activationId", activationId);
 
         stepContext.getStepLogger().writeItem(

--- a/powerauth-java-cmd-lib/src/main/java/com/wultra/security/powerauth/lib/cmd/steps/SignAsymmetricStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/com/wultra/security/powerauth/lib/cmd/steps/SignAsymmetricStep.java
@@ -161,6 +161,7 @@ public class SignAsymmetricStep extends AbstractBaseStep<SignAsymmetricStepModel
         if (requestDataBytes == null) {
             stepContext.getStepLogger().writeError(getStep().id() + "-read-data-failed", "Reading request data failed", "Could not read request data for signing");
             stepContext.getStepLogger().writeDoneFailed(getStep().id() + "-failed");
+            return;
         }
 
         stepContext.getStepLogger().writeItem(

--- a/powerauth-java-cmd-lib/src/main/java/com/wultra/security/powerauth/lib/cmd/steps/SignAsymmetricStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/com/wultra/security/powerauth/lib/cmd/steps/SignAsymmetricStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Wultra s.r.o.
+ * Copyright 2025 Wultra s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,9 +19,11 @@ import com.wultra.security.powerauth.crypto.client.keyfactory.PowerAuthClientKey
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptedResponse;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorId;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorScope;
+import com.wultra.security.powerauth.crypto.lib.enums.EcCurve;
 import com.wultra.security.powerauth.crypto.lib.util.KeyConvertor;
-import com.wultra.security.powerauth.crypto.lib.v4.api.PqcDsaKeyConvertor;
-import com.wultra.security.powerauth.crypto.lib.v4.ml.MlDsaKeyConvertor;
+import com.wultra.security.powerauth.crypto.lib.util.SignatureUtils;
+import com.wultra.security.powerauth.crypto.lib.v4.api.PqcDsa;
+import com.wultra.security.powerauth.crypto.lib.v4.ml.MlDsa;
 import com.wultra.security.powerauth.lib.cmd.consts.BackwardCompatibilityConst;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthStep;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
@@ -29,11 +31,11 @@ import com.wultra.security.powerauth.lib.cmd.header.PowerAuthHeaderFactory;
 import com.wultra.security.powerauth.lib.cmd.logging.StepLogger;
 import com.wultra.security.powerauth.lib.cmd.logging.StepLoggerFactory;
 import com.wultra.security.powerauth.lib.cmd.status.ResultStatusService;
+import com.wultra.security.powerauth.lib.cmd.steps.base.AbstractBaseStep;
 import com.wultra.security.powerauth.lib.cmd.steps.context.RequestContext;
 import com.wultra.security.powerauth.lib.cmd.steps.context.StepContext;
-import com.wultra.security.powerauth.lib.cmd.steps.model.VaultUnlockStepModel;
+import com.wultra.security.powerauth.lib.cmd.steps.model.SignAsymmetricStepModel;
 import com.wultra.security.powerauth.lib.cmd.steps.pojo.ResultStatusObject;
-import com.wultra.security.powerauth.lib.cmd.steps.base.AbstractBaseStep;
 import com.wultra.security.powerauth.lib.cmd.util.RestClientConfiguration;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.ParameterizedTypeReference;
@@ -47,7 +49,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
- * Helper class with vault unlock logic.
+ * Step for unlocking the device private keys using vault unlock and signing data using asymmetric algorithms.
  *
  * <p><b>PowerAuth protocol versions:</b>
  * <ul>
@@ -58,18 +60,22 @@ import java.util.Map;
  *      <li>4.0</li>
  * </ul>
  *
- * @author Lukas Lukovsky, lukas.lukovsky@wultra.com
  * @author Roman Strobl, roman.strobl@wultra.com
  */
-@Component("vaultUnlockStep")
-public class VaultUnlockStep extends AbstractBaseStep<VaultUnlockStepModel, EncryptedResponse> {
+@Component("signAsymmetricStep")
+public class SignAsymmetricStep extends AbstractBaseStep<SignAsymmetricStepModel, EncryptedResponse> {
+
+    private static final String REASON_VAULT_UNLOCK = "SIGN_DATA";
+    private static final String KEY_IDENTIFIER_KEK_DEVICE_PRIVATE = "KEK_DEVICE_PRIVATE";
 
     private final PowerAuthHeaderFactory powerAuthHeaderFactory;
 
     private static final KeyConvertor KEY_CONVERTOR_EC = new KeyConvertor();
-    private static final PqcDsaKeyConvertor KEY_CONVERTOR_PQC = new MlDsaKeyConvertor();
 
     private static final PowerAuthClientKeyFactory KEY_FACTORY = new PowerAuthClientKeyFactory();
+
+    private static final SignatureUtils SIGNATURE_UTILS = new SignatureUtils();
+    private static final PqcDsa PQC_DSA = new MlDsa();
 
     private static final com.wultra.security.powerauth.crypto.client.vault.PowerAuthClientVault VAULT_V3 = new com.wultra.security.powerauth.crypto.client.vault.PowerAuthClientVault();
     private static final com.wultra.security.powerauth.crypto.client.v4.vault.PowerAuthClientVault VAULT_V4 = new com.wultra.security.powerauth.crypto.client.v4.vault.PowerAuthClientVault();
@@ -81,11 +87,11 @@ public class VaultUnlockStep extends AbstractBaseStep<VaultUnlockStepModel, Encr
      * @param stepLoggerFactory Step logger factory
      */
     @Autowired
-    public VaultUnlockStep(
+    public SignAsymmetricStep(
             PowerAuthHeaderFactory powerAuthHeaderFactory,
             ResultStatusService resultStatusService,
             StepLoggerFactory stepLoggerFactory) {
-        super(PowerAuthStep.VAULT_UNLOCK, PowerAuthVersion.ALL_VERSIONS, resultStatusService, stepLoggerFactory);
+        super(PowerAuthStep.SIGN_ASYMMETRIC, PowerAuthVersion.ALL_VERSIONS, resultStatusService, stepLoggerFactory);
 
         this.powerAuthHeaderFactory = powerAuthHeaderFactory;
     }
@@ -93,7 +99,7 @@ public class VaultUnlockStep extends AbstractBaseStep<VaultUnlockStepModel, Encr
     /**
      * Constructor for backward compatibility
      */
-    public VaultUnlockStep() {
+    public SignAsymmetricStep() {
         this(
                 BackwardCompatibilityConst.POWER_AUTH_HEADER_FACTORY,
                 BackwardCompatibilityConst.RESULT_STATUS_SERVICE,
@@ -107,8 +113,8 @@ public class VaultUnlockStep extends AbstractBaseStep<VaultUnlockStepModel, Encr
     }
 
     @Override
-    public StepContext<VaultUnlockStepModel, EncryptedResponse> prepareStepContext(StepLogger stepLogger, Map<String, Object> context) throws Exception {
-        final VaultUnlockStepModel model = new VaultUnlockStepModel();
+    public StepContext<SignAsymmetricStepModel, EncryptedResponse> prepareStepContext(StepLogger stepLogger, Map<String, Object> context) throws Exception {
+        final SignAsymmetricStepModel model = new SignAsymmetricStepModel();
         model.fromMap(context);
 
         final int majorVersion = model.getVersion().getMajorVersion();
@@ -118,38 +124,20 @@ public class VaultUnlockStep extends AbstractBaseStep<VaultUnlockStepModel, Encr
                 .uri(model.getUriString() + "/pa/v" + majorVersion + "/vault/unlock")
                 .build();
 
-        final StepContext<VaultUnlockStepModel, EncryptedResponse> stepContext =
+        final StepContext<SignAsymmetricStepModel, EncryptedResponse> stepContext =
                 buildStepContext(stepLogger, model, requestContext);
 
         // Prepare vault unlock request payload
         final byte[] requestBytesPayload = switch (majorVersion) {
             case 3 -> {
                 final com.wultra.security.powerauth.rest.api.model.request.v3.VaultUnlockRequestPayload requestPayload = new com.wultra.security.powerauth.rest.api.model.request.v3.VaultUnlockRequestPayload();
-                requestPayload.setReason(model.getReason());
+                requestPayload.setReason(REASON_VAULT_UNLOCK);
                 yield RestClientConfiguration.defaultMapper().writeValueAsBytes(requestPayload);
             }
             case 4 -> {
-                if (model.getKeyIdentifier() == null) {
-                    stepContext.getStepLogger().writeError(
-                            getStep().id() + "-vault-unlock-failed",
-                            "Vault Unlock Failed",
-                            "Key identifier is not specified");
-                    stepContext.getStepLogger().writeDoneFailed(getStep().id() + "-failed");
-                    yield null;
-                }
-                if (!model.getKeyIdentifier().equals("KEK_DEVICE_PRIVATE")
-                        && !model.getKeyIdentifier().equals("KDK_APP_VAULT_KNOWLEDGE")
-                        && !model.getKeyIdentifier().equals("KDK_APP_VAULT_2FA")) {
-                    stepContext.getStepLogger().writeError(
-                            getStep().id() + "-vault-unlock-failed",
-                            "Vault Unlock Failed",
-                            "Key identifier is not valid");
-                    stepContext.getStepLogger().writeDoneFailed(getStep().id() + "-failed");
-                    yield null;
-                }
                 final com.wultra.security.powerauth.rest.api.model.request.v4.VaultUnlockRequestPayload requestPayload = new com.wultra.security.powerauth.rest.api.model.request.v4.VaultUnlockRequestPayload();
-                requestPayload.setKeyIdentifier(model.getKeyIdentifier());
-                requestPayload.setReason(model.getReason());
+                requestPayload.setKeyIdentifier(KEY_IDENTIFIER_KEK_DEVICE_PRIVATE);
+                requestPayload.setReason(REASON_VAULT_UNLOCK);
                 yield RestClientConfiguration.defaultMapper().writeValueAsBytes(requestPayload);
             }
             default -> throw new IllegalArgumentException("Unsupported version: " + stepContext.getModel().getVersion());
@@ -169,8 +157,23 @@ public class VaultUnlockStep extends AbstractBaseStep<VaultUnlockStepModel, Encr
     }
 
     @Override
-    public void processResponse(StepContext<VaultUnlockStepModel, EncryptedResponse> stepContext) throws Exception {
+    public void processResponse(StepContext<SignAsymmetricStepModel, EncryptedResponse> stepContext) throws Exception {
         final int majorVersion = stepContext.getModel().getVersion().getMajorVersion();
+
+        // Read data which needs to be encrypted
+        final byte[] requestDataBytes = stepContext.getModel().getData();
+        if (requestDataBytes == null) {
+            stepContext.getStepLogger().writeError(getStep().id() + "-read-data-failed", "Reading request data failed", "Could not read request data for signing");
+            stepContext.getStepLogger().writeDoneFailed(getStep().id() + "-failed");
+        }
+
+        stepContext.getStepLogger().writeItem(
+                getStep().id() + "-request-encrypt",
+                "Preparing Request Data",
+                "Following data will be encrypted",
+                "OK",
+                requestDataBytes
+        );
 
         final Map<String, Object> objectMap = new LinkedHashMap<>();
         switch (majorVersion) {
@@ -197,41 +200,50 @@ public class VaultUnlockStep extends AbstractBaseStep<VaultUnlockStepModel, Encr
 
                 final SecretKey masterSecretKey = KEY_FACTORY.generateClientMasterSecretKey(devicePrivateKey, serverPublicKey);
                 final SecretKey transportKeyDeduced = KEY_FACTORY.generateServerTransportKey(masterSecretKey);
-                final boolean equal = transportKeyDeduced.equals(transportMasterKey);
+                final boolean transportKeysEqual = transportKeyDeduced.equals(transportMasterKey);
+
+                if (!transportKeysEqual) {
+                    stepContext.getStepLogger().writeError(
+                            getStep().id() + "-vault-unlock-failed",
+                            "Vault Unlock Failed",
+                            "The transportMasterKey is invalid");
+                    stepContext.getStepLogger().writeDoneFailed(getStep().id() + "-failed");
+                    return;
+                }
+
+                final byte[] signature = SIGNATURE_UTILS.computeECDSASignature(EcCurve.P256, requestDataBytes, devicePrivateKey);
+
                 objectMap.put("activationId", resultStatusObject.getActivationId());
-                objectMap.put("encryptedVaultEncryptionKey", Base64.getEncoder().encodeToString(encryptedVaultEncryptionKey));
-                objectMap.put("transportMasterKey", Base64.getEncoder().encodeToString(KEY_CONVERTOR_EC.convertSharedSecretKeyToBytes(transportMasterKey)));
-                objectMap.put("vaultEncryptionKey", Base64.getEncoder().encodeToString(KEY_CONVERTOR_EC.convertSharedSecretKeyToBytes(vaultEncryptionKey)));
-                objectMap.put("devicePrivateKey", Base64.getEncoder().encodeToString(KEY_CONVERTOR_EC.convertPrivateKeyToBytes(devicePrivateKey)));
-                objectMap.put("privateKeyDecryptionSuccessful", (equal ? "true" : "false"));
+                objectMap.put("signature", Base64.getEncoder().encodeToString(signature));
             }
             case 4 -> {
                 final com.wultra.security.powerauth.rest.api.model.response.v4.VaultUnlockResponsePayload responsePayload = decryptResponse(stepContext, com.wultra.security.powerauth.rest.api.model.response.v4.VaultUnlockResponsePayload.class);
                 final ResultStatusObject resultStatusObject = stepContext.getModel().getResultStatus();
                 objectMap.put("activationId", resultStatusObject.getActivationId());
-                objectMap.put("vaultEncryptionKey", responsePayload.getVaultEncryptionKey());
 
                 // Decrypt and show device private keys in case key identifier is KEK_DEVICE_PRIVATE
-                if ("KEK_DEVICE_PRIVATE".equals(stepContext.getModel().getKeyIdentifier())) {
-                    final byte[] vaultUnlockKekDevicePrivateBytes = Base64.getDecoder().decode(responsePayload.getVaultEncryptionKey());
-                    final SecretKey vaultUnlockKekDevicePrivate = KEY_CONVERTOR_EC.convertBytesToSharedSecretKey(vaultUnlockKekDevicePrivateBytes);
-                    final byte[] encryptedEcDevicePrivateKeyBytes = Base64.getDecoder().decode(resultStatusObject.getEncryptedEcDevicePrivateKey());
-                    final PrivateKey encryptedEcDevicePrivateKey = VAULT_V4.decryptEcDevicePrivateKey(encryptedEcDevicePrivateKeyBytes, vaultUnlockKekDevicePrivate);
-                    objectMap.put("deviceEcPrivateKey", Base64.getEncoder().encodeToString(KEY_CONVERTOR_EC.convertPrivateKeyToBytes(encryptedEcDevicePrivateKey)));
-                    if (resultStatusObject.getEncryptedPqcDevicePrivateKey() != null) {
-                        final byte[] encryptedPqcDevicePrivateKeyBytes = Base64.getDecoder().decode(resultStatusObject.getEncryptedPqcDevicePrivateKey());
-                        final PrivateKey encryptedPqcDevicePrivateKey = VAULT_V4.decryptPqcDevicePrivateKey(encryptedPqcDevicePrivateKeyBytes, vaultUnlockKekDevicePrivate);
-                        objectMap.put("devicePqcPrivateKey", Base64.getEncoder().encodeToString(KEY_CONVERTOR_PQC.convertPrivateKeyToBytes(encryptedPqcDevicePrivateKey)));
-                    }
+                final byte[] vaultUnlockKekDevicePrivateBytes = Base64.getDecoder().decode(responsePayload.getVaultEncryptionKey());
+                final SecretKey vaultUnlockKekDevicePrivate = KEY_CONVERTOR_EC.convertBytesToSharedSecretKey(vaultUnlockKekDevicePrivateBytes);
+                final byte[] encryptedEcDevicePrivateKeyBytes = Base64.getDecoder().decode(resultStatusObject.getEncryptedEcDevicePrivateKey());
+                final PrivateKey ecDevicePrivateKey = VAULT_V4.decryptEcDevicePrivateKey(encryptedEcDevicePrivateKeyBytes, vaultUnlockKekDevicePrivate);
+                final byte[] signatureEc = SIGNATURE_UTILS.computeECDSASignature(EcCurve.P384, requestDataBytes, ecDevicePrivateKey);
+                objectMap.put("signatureEc", Base64.getEncoder().encodeToString(signatureEc));
+
+                if (resultStatusObject.getEncryptedPqcDevicePrivateKey() != null) {
+                    final byte[] encryptedPqcDevicePrivateKeyBytes = Base64.getDecoder().decode(resultStatusObject.getEncryptedPqcDevicePrivateKey());
+                    final PrivateKey pqcDevicePrivateKey = VAULT_V4.decryptPqcDevicePrivateKey(encryptedPqcDevicePrivateKeyBytes, vaultUnlockKekDevicePrivate);
+                    final byte[] signaturePqc = PQC_DSA.sign(pqcDevicePrivateKey, requestDataBytes);
+                    objectMap.put("signaturePqc", Base64.getEncoder().encodeToString(signaturePqc));
                 }
+
             }
             default -> throw new IllegalArgumentException("Unsupported version: " + stepContext.getModel().getVersion());
         }
 
         stepContext.getStepLogger().writeItem(
-                getStep().id() + "-vault-unlocked",
-                "Vault Unlocked",
-                "Secure vault was successfully unlocked",
+                getStep().id() + "-",
+                "Sign Asymmetric Succeeded",
+                "Secure vault was successfully unlocked and request data was signed successfully",
                 "OK",
                 objectMap
         );

--- a/powerauth-java-cmd-lib/src/main/java/com/wultra/security/powerauth/lib/cmd/steps/SignAsymmetricStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/com/wultra/security/powerauth/lib/cmd/steps/SignAsymmetricStep.java
@@ -143,10 +143,6 @@ public class SignAsymmetricStep extends AbstractBaseStep<SignAsymmetricStepModel
             default -> throw new IllegalArgumentException("Unsupported version: " + stepContext.getModel().getVersion());
         };
 
-        if (requestBytesPayload == null) {
-            return null;
-        }
-
         addEncryptedRequest(stepContext, model.getApplicationKey(), model.getApplicationSecret(), EncryptorId.VAULT_UNLOCK, requestBytesPayload, EncryptorScope.ACTIVATION_SCOPE);
 
         powerAuthHeaderFactory.getHeaderProvider(model).addHeader(stepContext);

--- a/powerauth-java-cmd-lib/src/main/java/com/wultra/security/powerauth/lib/cmd/steps/SignAsymmetricStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/com/wultra/security/powerauth/lib/cmd/steps/SignAsymmetricStep.java
@@ -197,9 +197,8 @@ public class SignAsymmetricStep extends AbstractBaseStep<SignAsymmetricStepModel
 
                 final SecretKey masterSecretKey = KEY_FACTORY.generateClientMasterSecretKey(devicePrivateKey, serverPublicKey);
                 final SecretKey transportKeyDeduced = KEY_FACTORY.generateServerTransportKey(masterSecretKey);
-                final boolean transportKeysEqual = transportKeyDeduced.equals(transportMasterKey);
 
-                if (!transportKeysEqual) {
+                if (!transportKeyDeduced.equals(transportMasterKey)) {
                     stepContext.getStepLogger().writeError(
                             getStep().id() + "-vault-unlock-failed",
                             "Vault Unlock Failed",

--- a/powerauth-java-cmd-lib/src/main/java/com/wultra/security/powerauth/lib/cmd/steps/SignAsymmetricStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/com/wultra/security/powerauth/lib/cmd/steps/SignAsymmetricStep.java
@@ -65,7 +65,7 @@ import java.util.Map;
 @Component("signAsymmetricStep")
 public class SignAsymmetricStep extends AbstractBaseStep<SignAsymmetricStepModel, EncryptedResponse> {
 
-    private static final String REASON_VAULT_UNLOCK = "SIGN_DATA";
+    private static final String REASON_VAULT_UNLOCK = "SIGN_WITH_DEVICE_PRIVATE_KEY";
     private static final String KEY_IDENTIFIER_KEK_DEVICE_PRIVATE = "KEK_DEVICE_PRIVATE";
 
     private final PowerAuthHeaderFactory powerAuthHeaderFactory;

--- a/powerauth-java-cmd-lib/src/main/java/com/wultra/security/powerauth/lib/cmd/steps/VaultUnlockStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/com/wultra/security/powerauth/lib/cmd/steps/VaultUnlockStep.java
@@ -213,12 +213,12 @@ public class VaultUnlockStep extends AbstractBaseStep<VaultUnlockStepModel, Encr
                     final byte[] vaultUnlockKekDevicePrivateBytes = Base64.getDecoder().decode(responsePayload.getVaultEncryptionKey());
                     final SecretKey vaultUnlockKekDevicePrivate = KEY_CONVERTOR_EC.convertBytesToSharedSecretKey(vaultUnlockKekDevicePrivateBytes);
                     final byte[] encryptedEcDevicePrivateKeyBytes = Base64.getDecoder().decode(resultStatusObject.getEncryptedEcDevicePrivateKey());
-                    final PrivateKey encryptedEcDevicePrivateKey = VAULT_V4.decryptEcDevicePrivateKey(encryptedEcDevicePrivateKeyBytes, vaultUnlockKekDevicePrivate);
-                    objectMap.put("deviceEcPrivateKey", Base64.getEncoder().encodeToString(KEY_CONVERTOR_EC.convertPrivateKeyToBytes(encryptedEcDevicePrivateKey)));
+                    final PrivateKey ecDevicePrivateKey = VAULT_V4.decryptEcDevicePrivateKey(encryptedEcDevicePrivateKeyBytes, vaultUnlockKekDevicePrivate);
+                    objectMap.put("deviceEcPrivateKey", Base64.getEncoder().encodeToString(KEY_CONVERTOR_EC.convertPrivateKeyToBytes(ecDevicePrivateKey)));
                     if (resultStatusObject.getEncryptedPqcDevicePrivateKey() != null) {
                         final byte[] encryptedPqcDevicePrivateKeyBytes = Base64.getDecoder().decode(resultStatusObject.getEncryptedPqcDevicePrivateKey());
-                        final PrivateKey encryptedPqcDevicePrivateKey = VAULT_V4.decryptPqcDevicePrivateKey(encryptedPqcDevicePrivateKeyBytes, vaultUnlockKekDevicePrivate);
-                        objectMap.put("devicePqcPrivateKey", Base64.getEncoder().encodeToString(KEY_CONVERTOR_PQC.convertPrivateKeyToBytes(encryptedPqcDevicePrivateKey)));
+                        final PrivateKey pqcDevicePrivateKey = VAULT_V4.decryptPqcDevicePrivateKey(encryptedPqcDevicePrivateKeyBytes, vaultUnlockKekDevicePrivate);
+                        objectMap.put("devicePqcPrivateKey", Base64.getEncoder().encodeToString(KEY_CONVERTOR_PQC.convertPrivateKeyToBytes(pqcDevicePrivateKey)));
                     }
                 }
             }

--- a/powerauth-java-cmd-lib/src/main/java/com/wultra/security/powerauth/lib/cmd/steps/VaultUnlockStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/com/wultra/security/powerauth/lib/cmd/steps/VaultUnlockStep.java
@@ -212,11 +212,11 @@ public class VaultUnlockStep extends AbstractBaseStep<VaultUnlockStepModel, Encr
                 if ("KEK_DEVICE_PRIVATE".equals(stepContext.getModel().getKeyIdentifier())) {
                     final byte[] vaultUnlockKekDevicePrivateBytes = Base64.getDecoder().decode(responsePayload.getVaultEncryptionKey());
                     final SecretKey vaultUnlockKekDevicePrivate = KEY_CONVERTOR_EC.convertBytesToSharedSecretKey(vaultUnlockKekDevicePrivateBytes);
-                    final byte[] encryptedEcDevicePrivateKeyBytes = Base64.getDecoder().decode(resultStatusObject.getEncryptedEcDevicePrivateKey());
+                    final byte[] encryptedEcDevicePrivateKeyBytes = resultStatusObject.getEncryptedEcDevicePrivateKeyBytes();
                     final PrivateKey ecDevicePrivateKey = VAULT_V4.decryptEcDevicePrivateKey(encryptedEcDevicePrivateKeyBytes, vaultUnlockKekDevicePrivate);
                     objectMap.put("deviceEcPrivateKey", Base64.getEncoder().encodeToString(KEY_CONVERTOR_EC.convertPrivateKeyToBytes(ecDevicePrivateKey)));
                     if (resultStatusObject.getEncryptedPqcDevicePrivateKey() != null) {
-                        final byte[] encryptedPqcDevicePrivateKeyBytes = Base64.getDecoder().decode(resultStatusObject.getEncryptedPqcDevicePrivateKey());
+                        final byte[] encryptedPqcDevicePrivateKeyBytes = resultStatusObject.getEncryptedPqcDevicePrivateKeyBytes();
                         final PrivateKey pqcDevicePrivateKey = VAULT_V4.decryptPqcDevicePrivateKey(encryptedPqcDevicePrivateKeyBytes, vaultUnlockKekDevicePrivate);
                         objectMap.put("devicePqcPrivateKey", Base64.getEncoder().encodeToString(KEY_CONVERTOR_PQC.convertPrivateKeyToBytes(pqcDevicePrivateKey)));
                     }

--- a/powerauth-java-cmd-lib/src/main/java/com/wultra/security/powerauth/lib/cmd/steps/VaultUnlockStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/com/wultra/security/powerauth/lib/cmd/steps/VaultUnlockStep.java
@@ -16,11 +16,12 @@
 package com.wultra.security.powerauth.lib.cmd.steps;
 
 import com.wultra.security.powerauth.crypto.client.keyfactory.PowerAuthClientKeyFactory;
-import com.wultra.security.powerauth.crypto.client.vault.PowerAuthClientVault;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptedResponse;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorId;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorScope;
 import com.wultra.security.powerauth.crypto.lib.util.KeyConvertor;
+import com.wultra.security.powerauth.crypto.lib.v4.api.PqcDsaKeyConvertor;
+import com.wultra.security.powerauth.crypto.lib.v4.ml.MlDsaKeyConvertor;
 import com.wultra.security.powerauth.lib.cmd.consts.BackwardCompatibilityConst;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthStep;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
@@ -42,7 +43,7 @@ import javax.crypto.SecretKey;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.util.Base64;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -65,9 +66,13 @@ public class VaultUnlockStep extends AbstractBaseStep<VaultUnlockStepModel, Encr
 
     private final PowerAuthHeaderFactory powerAuthHeaderFactory;
 
-    private static final KeyConvertor KEY_CONVERTOR = new KeyConvertor();
+    private static final KeyConvertor KEY_CONVERTOR_EC = new KeyConvertor();
+    private static final PqcDsaKeyConvertor KEY_CONVERTOR_PQC = new MlDsaKeyConvertor();
 
     private static final PowerAuthClientKeyFactory KEY_FACTORY = new PowerAuthClientKeyFactory();
+
+    private static final com.wultra.security.powerauth.crypto.client.vault.PowerAuthClientVault VAULT_V3 = new com.wultra.security.powerauth.crypto.client.vault.PowerAuthClientVault();
+    private static final com.wultra.security.powerauth.crypto.client.v4.vault.PowerAuthClientVault VAULT_V4 = new com.wultra.security.powerauth.crypto.client.v4.vault.PowerAuthClientVault();
 
     /**
      * Constructor
@@ -165,7 +170,7 @@ public class VaultUnlockStep extends AbstractBaseStep<VaultUnlockStepModel, Encr
     public void processResponse(StepContext<VaultUnlockStepModel, EncryptedResponse> stepContext) throws Exception {
         final int majorVersion = stepContext.getModel().getVersion().getMajorVersion();
 
-        final Map<String, Object> objectMap = new HashMap<>();
+        final Map<String, Object> objectMap = new LinkedHashMap<>();
         switch (majorVersion) {
             case 3 -> {
                 final com.wultra.security.powerauth.rest.api.model.response.v3.VaultUnlockResponsePayload responsePayload = decryptResponse(stepContext, com.wultra.security.powerauth.rest.api.model.response.v3.VaultUnlockResponsePayload.class);
@@ -180,12 +185,11 @@ public class VaultUnlockStep extends AbstractBaseStep<VaultUnlockStepModel, Encr
                     return;
                 }
 
-                final byte[] encryptedDevicePrivateKeyBytes = resultStatusObject.getEncryptedDevicePrivateKeyBytes();
+                final byte[] encryptedDevicePrivateKeyBytes = resultStatusObject.getEncryptedEcDevicePrivateKeyBytes();
                 final byte[] encryptedVaultEncryptionKey = Base64.getDecoder().decode(responsePayload.getEncryptedVaultEncryptionKey());
 
-                final PowerAuthClientVault vault = new PowerAuthClientVault();
-                final SecretKey vaultEncryptionKey = vault.decryptVaultEncryptionKey(encryptedVaultEncryptionKey, transportMasterKey);
-                final PrivateKey devicePrivateKey = vault.decryptDevicePrivateKey(encryptedDevicePrivateKeyBytes, vaultEncryptionKey);
+                final SecretKey vaultEncryptionKey = VAULT_V3.decryptVaultEncryptionKey(encryptedVaultEncryptionKey, transportMasterKey);
+                final PrivateKey devicePrivateKey = VAULT_V3.decryptDevicePrivateKey(encryptedDevicePrivateKeyBytes, vaultEncryptionKey);
                 final PublicKey serverPublicKey = resultStatusObject.getEcServerPublicKeyObject();
 
                 final SecretKey masterSecretKey = KEY_FACTORY.generateClientMasterSecretKey(devicePrivateKey, serverPublicKey);
@@ -193,9 +197,9 @@ public class VaultUnlockStep extends AbstractBaseStep<VaultUnlockStepModel, Encr
                 final boolean equal = transportKeyDeduced.equals(transportMasterKey);
                 objectMap.put("activationId", resultStatusObject.getActivationId());
                 objectMap.put("encryptedVaultEncryptionKey", Base64.getEncoder().encodeToString(encryptedVaultEncryptionKey));
-                objectMap.put("transportMasterKey", Base64.getEncoder().encodeToString(KEY_CONVERTOR.convertSharedSecretKeyToBytes(transportMasterKey)));
-                objectMap.put("vaultEncryptionKey", Base64.getEncoder().encodeToString(KEY_CONVERTOR.convertSharedSecretKeyToBytes(vaultEncryptionKey)));
-                objectMap.put("devicePrivateKey", Base64.getEncoder().encodeToString(KEY_CONVERTOR.convertPrivateKeyToBytes(devicePrivateKey)));
+                objectMap.put("transportMasterKey", Base64.getEncoder().encodeToString(KEY_CONVERTOR_EC.convertSharedSecretKeyToBytes(transportMasterKey)));
+                objectMap.put("vaultEncryptionKey", Base64.getEncoder().encodeToString(KEY_CONVERTOR_EC.convertSharedSecretKeyToBytes(vaultEncryptionKey)));
+                objectMap.put("devicePrivateKey", Base64.getEncoder().encodeToString(KEY_CONVERTOR_EC.convertPrivateKeyToBytes(devicePrivateKey)));
                 objectMap.put("privateKeyDecryptionSuccessful", (equal ? "true" : "false"));
             }
             case 4 -> {
@@ -203,6 +207,20 @@ public class VaultUnlockStep extends AbstractBaseStep<VaultUnlockStepModel, Encr
                 final ResultStatusObject resultStatusObject = stepContext.getModel().getResultStatus();
                 objectMap.put("activationId", resultStatusObject.getActivationId());
                 objectMap.put("vaultEncryptionKey", responsePayload.getVaultEncryptionKey());
+
+                // Decrypt and show device private keys in case key identifier is KEK_DEVICE_PRIVATE
+                if ("KEK_DEVICE_PRIVATE".equals(stepContext.getModel().getKeyIdentifier())) {
+                    final byte[] vaultUnlockKekDevicePrivateBytes = Base64.getDecoder().decode(responsePayload.getVaultEncryptionKey());
+                    final SecretKey vaultUnlockKekDevicePrivate = KEY_CONVERTOR_EC.convertBytesToSharedSecretKey(vaultUnlockKekDevicePrivateBytes);
+                    final byte[] encryptedEcDevicePrivateKeyBytes = Base64.getDecoder().decode(resultStatusObject.getEncryptedEcDevicePrivateKey());
+                    final PrivateKey encryptedEcDevicePrivateKey = VAULT_V4.decryptEcDevicePrivateKey(encryptedEcDevicePrivateKeyBytes, vaultUnlockKekDevicePrivate);
+                    objectMap.put("deviceEcPrivateKey", Base64.getEncoder().encodeToString(KEY_CONVERTOR_EC.convertPrivateKeyToBytes(encryptedEcDevicePrivateKey)));
+                    if (resultStatusObject.getEncryptedPqcDevicePrivateKey() != null) {
+                        final byte[] encryptedPqcDevicePrivateKeyBytes = Base64.getDecoder().decode(resultStatusObject.getEncryptedPqcDevicePrivateKey());
+                        final PrivateKey encryptedPqcDevicePrivateKey = VAULT_V4.decryptPqcDevicePrivateKey(encryptedPqcDevicePrivateKeyBytes, vaultUnlockKekDevicePrivate);
+                        objectMap.put("devicePqcPrivateKey", Base64.getEncoder().encodeToString(KEY_CONVERTOR_PQC.convertPrivateKeyToBytes(encryptedPqcDevicePrivateKey)));
+                    }
+                }
             }
             default -> throw new IllegalArgumentException("Unsupported version: " + stepContext.getModel().getVersion());
         }

--- a/powerauth-java-cmd-lib/src/main/java/com/wultra/security/powerauth/lib/cmd/steps/base/AbstractActivationStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/com/wultra/security/powerauth/lib/cmd/steps/base/AbstractActivationStep.java
@@ -17,7 +17,6 @@
 package com.wultra.security.powerauth.lib.cmd.steps.base;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.wultra.security.powerauth.crypto.client.vault.PowerAuthClientVault;
 import com.wultra.security.powerauth.crypto.lib.encryptor.ClientEncryptor;
 import com.wultra.security.powerauth.crypto.lib.encryptor.EncryptorFactory;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.*;
@@ -89,7 +88,8 @@ public abstract class AbstractActivationStep<M extends ActivationData> extends A
 
     private static final KeyGenerator KEY_GENERATOR = new KeyGenerator();
 
-    private static final PowerAuthClientVault VAULT = new PowerAuthClientVault();
+    private static final com.wultra.security.powerauth.crypto.client.vault.PowerAuthClientVault VAULT_V3 = new com.wultra.security.powerauth.crypto.client.vault.PowerAuthClientVault();
+    private static final com.wultra.security.powerauth.crypto.client.v4.vault.PowerAuthClientVault VAULT_V4 = new com.wultra.security.powerauth.crypto.client.v4.vault.PowerAuthClientVault();
 
     private static final ObjectMapper MAPPER = RestClientConfiguration.defaultMapper();
 
@@ -128,7 +128,7 @@ public abstract class AbstractActivationStep<M extends ActivationData> extends A
 
         resultStatusService.save(model);
 
-        final Map<String, Object> objectMap = new HashMap<>();
+        final Map<String, Object> objectMap = new LinkedHashMap<>();
         objectMap.put("activationId", resultStatusObject.getActivationId());
         objectMap.put("activationStatusFile", model.getStatusFileName());
         objectMap.put("activationStatusFileContent", model.getResultStatus());
@@ -220,7 +220,7 @@ public abstract class AbstractActivationStep<M extends ActivationData> extends A
         final SecretKey vaultUnlockMasterKey = KEY_FACTORY_V3.generateServerEncryptedVaultKey(masterSecretKey);
 
         // Encrypt the original device private key using the vault unlock key
-        final byte[] encryptedDevicePrivateKey = VAULT.encryptDevicePrivateKey(securityContext.getEcDeviceKeyPair().getPrivate(), vaultUnlockMasterKey);
+        final byte[] encryptedDevicePrivateKey = VAULT_V3.encryptDevicePrivateKey(securityContext.getEcDeviceKeyPair().getPrivate(), vaultUnlockMasterKey);
 
         final char[] password;
         if (model.getPassword() == null) {
@@ -240,7 +240,7 @@ public abstract class AbstractActivationStep<M extends ActivationData> extends A
         resultStatusObject.setActivationId(activationId);
         resultStatusObject.setCounter(0L);
         resultStatusObject.setCtrData(ctrDataBase64);
-        resultStatusObject.setEncryptedDevicePrivateKeyBytes(encryptedDevicePrivateKey);
+        resultStatusObject.setEncryptedEcDevicePrivateKeyBytes(encryptedDevicePrivateKey);
         resultStatusObject.setEcServerPublicKeyObject(serverPublicKey);
         resultStatusObject.setBiometryFactorKeyObject(biometryFactorKey);
         resultStatusObject.setKnowledgeFactorKeyEncryptedBytes(cKnowledgeFactorSecretKey);
@@ -314,6 +314,7 @@ public abstract class AbstractActivationStep<M extends ActivationData> extends A
         final SecretKey authenticationCodePossessionSecretKey = KEY_FACTORY_V4.generatePossessionFactorKey(activationSharedSecret);
         final SecretKey authenticationCodeKnowledgeSecretKey = KEY_FACTORY_V4.generateKnowledgeFactorKey(activationSharedSecret);
         final SecretKey authenticationCodeBiometrySecretKey = KEY_FACTORY_V4.generateBiometryFactorKey(activationSharedSecret);
+        final SecretKey vaultUnlockKekDevicePrivate = KEY_FACTORY_V4.generateKeyKekDevicePrivate(activationSharedSecret);
 
         final char[] password;
         if (model.getPassword() == null) {
@@ -331,6 +332,15 @@ public abstract class AbstractActivationStep<M extends ActivationData> extends A
         final PublicKey ecDevicePublicKey = securityContext.getEcDeviceKeyPair().getPublic();
         final PublicKey pqcDevicePublicKey = securityContext.getPqcDeviceKeyPair() != null ? securityContext.getPqcDeviceKeyPair().getPublic() : null;
 
+        // Encrypt device private keys
+        final byte[] encryptedEcDevicePrivateKey = VAULT_V4.encryptEcDevicePrivateKey(securityContext.getEcDeviceKeyPair().getPrivate(), vaultUnlockKekDevicePrivate);
+        final byte[] encryptedPqcDevicePrivateKey;
+        if (securityContext.getPqcDeviceKeyPair() != null) {
+            encryptedPqcDevicePrivateKey = VAULT_V4.encryptPqcDevicePrivateKey(securityContext.getPqcDeviceKeyPair().getPrivate(), vaultUnlockKekDevicePrivate);
+        } else {
+            encryptedPqcDevicePrivateKey = null;
+        }
+
         resultStatusObject.setVersion((long) model.getVersion().getMajorVersion());
         resultStatusObject.setActivationId(activationId);
         resultStatusObject.setCounter(0L);
@@ -342,7 +352,10 @@ public abstract class AbstractActivationStep<M extends ActivationData> extends A
         if (serverPublicKeys.getMldsa() != null) {
             resultStatusObject.setPqcServerPublicKey(serverPublicKeys.getMldsa());
         }
-        // TODO - store encrypted crypto 4 private keys using updated vault mechanism
+        resultStatusObject.setEncryptedEcDevicePrivateKeyBytes(encryptedEcDevicePrivateKey);
+        if (encryptedPqcDevicePrivateKey != null) {
+            resultStatusObject.setEncryptedPqcDevicePrivateKeyBytes(encryptedPqcDevicePrivateKey);
+        }
         resultStatusObject.setBiometryFactorKeyObject(authenticationCodeBiometrySecretKey);
         resultStatusObject.setKnowledgeFactorKeyEncryptedBytes(encryptedKnowledgeSecretKey);
         resultStatusObject.setKnowledgeFactorKeySaltBytes(salt);

--- a/powerauth-java-cmd-lib/src/main/java/com/wultra/security/powerauth/lib/cmd/steps/base/AbstractBaseStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/com/wultra/security/powerauth/lib/cmd/steps/base/AbstractBaseStep.java
@@ -198,6 +198,7 @@ public abstract class AbstractBaseStep<M extends BaseStepData, R> implements Bas
                 stepLogger.writeDoneOK(getStep().id() + "-success");
             } else if (!isDryRun(stepContext.getModel())) {
                 stepContext.getStepLogger().writeDoneFailed(getStep().id() + "-failed");
+                return null;
             }
         } catch (Exception exception) {
             stepLogger.writeError(getStep().id() + "-error-generic", exception);

--- a/powerauth-java-cmd-lib/src/main/java/com/wultra/security/powerauth/lib/cmd/steps/model/SignAsymmetricStepModel.java
+++ b/powerauth-java-cmd-lib/src/main/java/com/wultra/security/powerauth/lib/cmd/steps/model/SignAsymmetricStepModel.java
@@ -1,0 +1,90 @@
+/*
+ * PowerAuth Command-line utility
+ * Copyright 2025 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.wultra.security.powerauth.lib.cmd.steps.model;
+
+import com.wultra.security.powerauth.crypto.lib.enums.PowerAuthCodeType;
+import com.wultra.security.powerauth.lib.cmd.steps.model.data.AuthorizationHeaderData;
+import com.wultra.security.powerauth.lib.cmd.steps.model.feature.ResultStatusChangeable;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import java.util.Map;
+
+/**
+ * Model representing parameters of the step for unlocking device private keys and signing using asymmetric algorithms.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class SignAsymmetricStepModel extends BaseStepModel
+        implements ResultStatusChangeable, AuthorizationHeaderData {
+
+    /**
+     * Application key.
+     */
+    private String applicationKey;
+
+    /**
+     * Application secret.
+     */
+    private String applicationSecret;
+
+    /**
+     * File name of the file with stored activation status.
+     */
+    private String statusFileName;
+
+    /**
+     * PowerAuth authentication code type
+     */
+    private PowerAuthCodeType authenticationCodeType;
+
+    /**
+     * Password for the password related key encryption.
+     */
+    private String password;
+
+    /**
+     * The signed data.
+     */
+    private byte[] data;
+
+    @Override
+    public Map<String, Object> toMap() {
+        Map<String, Object> context = super.toMap();
+        context.put("STATUS_FILENAME", statusFileName);
+        context.put("APPLICATION_KEY", applicationKey);
+        context.put("APPLICATION_SECRET", applicationSecret);
+        context.put("AUTHENTICATION_CODE_TYPE", authenticationCodeType.toString());
+        context.put("PASSWORD", password);
+        context.put("DATA", data);
+        return context;
+    }
+
+    @Override
+    public void fromMap(Map<String, Object> context) {
+        super.fromMap(context);
+        setStatusFileName((String) context.get("STATUS_FILENAME"));
+        setApplicationKey((String) context.get("APPLICATION_KEY"));
+        setApplicationSecret((String) context.get("APPLICATION_SECRET"));
+        setAuthenticationCodeType(PowerAuthCodeType.getEnumFromString((String) context.get("AUTHENTICATION_CODE_TYPE")));
+        setPassword((String) context.get("PASSWORD"));
+        setData((byte[]) context.get("DATA"));
+    }
+
+}

--- a/powerauth-java-cmd-lib/src/main/java/com/wultra/security/powerauth/lib/cmd/steps/pojo/ResultStatusObject.java
+++ b/powerauth-java-cmd-lib/src/main/java/com/wultra/security/powerauth/lib/cmd/steps/pojo/ResultStatusObject.java
@@ -109,12 +109,7 @@ public class ResultStatusObject {
      */
     @JsonIgnore
     public byte[] getEncryptedEcDevicePrivateKeyBytes() {
-        final int version = getVersion().intValue();
-        final String encryptedDevicePrivateKey = switch (version) {
-            case 3 -> (String) jsonObject.get("encryptedDevicePrivateKey");
-            case 4 -> (String) jsonObject.get("encryptedEcDevicePrivateKey");
-            default -> throw new IllegalStateException("Unsupported version: " + version);
-        };
+        final String encryptedDevicePrivateKey = (String) jsonObject.get("encryptedEcDevicePrivateKey");
         if (encryptedDevicePrivateKey == null) {
             return null;
         }
@@ -127,13 +122,8 @@ public class ResultStatusObject {
      */
     @JsonIgnore
     public void setEncryptedEcDevicePrivateKeyBytes(byte[] encryptedDevicePrivateKeyBytes) {
-        final int version = getVersion().intValue();
         final String encryptedDevicePrivateKey = Base64.getEncoder().encodeToString(encryptedDevicePrivateKeyBytes);
-        switch (version) {
-            case 3 -> jsonObject.put("encryptedDevicePrivateKey", encryptedDevicePrivateKey);
-            case 4 -> jsonObject.put("encryptedEcDevicePrivateKey", encryptedDevicePrivateKey);
-            default -> throw new IllegalStateException("Unsupported version: " + version);
-        }
+        jsonObject.put("encryptedEcDevicePrivateKey", encryptedDevicePrivateKey);
     }
 
     /**
@@ -185,12 +175,7 @@ public class ResultStatusObject {
      * @param encryptedDevicePrivateKey Encrypted EC device private key object
      */
     public void setEncryptedPqcDevicePrivateKey(String encryptedDevicePrivateKey) {
-        final int version = getVersion().intValue();
-        switch (version) {
-            case 3 -> jsonObject.put("encryptedDevicePrivateKey", encryptedDevicePrivateKey);
-            case 4 -> jsonObject.put("encryptedPqcDevicePrivateKey", encryptedDevicePrivateKey);
-            default -> throw new IllegalStateException("Unsupported version: " + version);
-        }
+        jsonObject.put("encryptedPqcDevicePrivateKey", encryptedDevicePrivateKey);
     }
 
     /**
@@ -214,24 +199,11 @@ public class ResultStatusObject {
      */
     @JsonIgnore
     public PublicKey getEcServerPublicKeyObject() throws Exception {
-        int version = getVersion().intValue();
-        return switch (version) {
-            case 3 -> {
-                String serverPublicKey = (String) jsonObject.get("serverPublicKey");
-                if (serverPublicKey == null) {
-                    yield null;
-                }
-                yield KEY_CONVERTOR_EC.convertBytesToPublicKey(EcCurve.P256, Base64.getDecoder().decode(serverPublicKey));
-            }
-            case 4 -> {
-                String serverPublicKey = (String) jsonObject.get("ecServerPublicKey");
-                if (serverPublicKey == null) {
-                    yield null;
-                }
-                yield KEY_CONVERTOR_EC.convertBytesToPublicKey(EcCurve.P384, Base64.getDecoder().decode(serverPublicKey));
-            }
-            default -> throw new IllegalStateException("Unsupported version: " + version);
-        };
+        String serverPublicKey = (String) jsonObject.get("ecServerPublicKey");
+        if (serverPublicKey == null) {
+            return null;
+        }
+        return KEY_CONVERTOR_EC.convertBytesToPublicKey(EcCurve.P384, Base64.getDecoder().decode(serverPublicKey));
     }
 
     /**
@@ -241,30 +213,15 @@ public class ResultStatusObject {
      */
     @JsonIgnore
     public void setEcServerPublicKeyObject(PublicKey serverPublicKeyObject) throws Exception {
-        int version = getVersion().intValue();
-        switch (version) {
-            case 3 -> {
-                String serverPublicKey = Base64.getEncoder().encodeToString(KEY_CONVERTOR_EC.convertPublicKeyToBytes(EcCurve.P256, serverPublicKeyObject));
-                jsonObject.put("serverPublicKey", serverPublicKey);
-            }
-            case 4 -> {
-                String serverPublicKey = Base64.getEncoder().encodeToString(KEY_CONVERTOR_EC.convertPublicKeyToBytes(EcCurve.P384, serverPublicKeyObject));
-                jsonObject.put("ecServerPublicKey", serverPublicKey);
-            }
-            default -> throw new IllegalStateException("Unsupported version: " + version);
-        }
+        String serverPublicKey = Base64.getEncoder().encodeToString(KEY_CONVERTOR_EC.convertPublicKeyToBytes(EcCurve.P384, serverPublicKeyObject));
+        jsonObject.put("ecServerPublicKey", serverPublicKey);
     }
 
     /**
      * @return Base64 encoded byte representation of the EC server public key
      */
     public String getEcServerPublicKey() {
-        int version = getVersion().intValue();
-        return switch (version) {
-            case 3 -> (String) jsonObject.get("serverPublicKey");
-            case 4 -> (String) jsonObject.get("ecServerPublicKey");
-            default -> throw new IllegalStateException("Unsupported version: " + version);
-        };
+        return (String) jsonObject.get("ecServerPublicKey");
     }
 
     /**
@@ -272,12 +229,7 @@ public class ResultStatusObject {
      * @param serverPublicKey Public key as base64
      */
     public void setEcServerPublicKey(String serverPublicKey) {
-        int version = getVersion().intValue();
-        switch (version) {
-            case 3 -> jsonObject.put("serverPublicKey", serverPublicKey);
-            case 4 -> jsonObject.put("ecServerPublicKey", serverPublicKey);
-            default -> throw new IllegalStateException("Unsupported version: " + version);
-        }
+        jsonObject.put("ecServerPublicKey", serverPublicKey);
     }
 
     /**
@@ -325,24 +277,11 @@ public class ResultStatusObject {
      */
     @JsonIgnore
     public PublicKey getEcDevicePublicKeyObject() throws Exception {
-        int version = getVersion().intValue();
-        return switch (version) {
-            case 3 -> {
-                String devicePublicKey = (String) jsonObject.get("devicePublicKey");
-                if (devicePublicKey == null) {
-                    yield null;
-                }
-                yield KEY_CONVERTOR_EC.convertBytesToPublicKey(EcCurve.P256, Base64.getDecoder().decode(devicePublicKey));
-            }
-            case 4 -> {
-                String devicePublicKey = (String) jsonObject.get("ecDevicePublicKey");
-                if (devicePublicKey == null) {
-                    yield null;
-                }
-                yield KEY_CONVERTOR_EC.convertBytesToPublicKey(EcCurve.P384, Base64.getDecoder().decode(devicePublicKey));
-            }
-            default -> throw new IllegalStateException("Unsupported version: " + version);
-        };
+        String devicePublicKey = (String) jsonObject.get("ecDevicePublicKey");
+        if (devicePublicKey == null) {
+            return null;
+        }
+        return KEY_CONVERTOR_EC.convertBytesToPublicKey(EcCurve.P384, Base64.getDecoder().decode(devicePublicKey));
     }
 
     /**
@@ -352,30 +291,15 @@ public class ResultStatusObject {
      */
     @JsonIgnore
     public void setEcDevicePublicKeyObject(PublicKey devicePublicKeyObject) throws Exception {
-        int version = getVersion().intValue();
-        switch (version) {
-            case 3 -> {
-                String devicePublicKey = Base64.getEncoder().encodeToString(KEY_CONVERTOR_EC.convertPublicKeyToBytes(EcCurve.P256, devicePublicKeyObject));
-                jsonObject.put("devicePublicKey", devicePublicKey);
-            }
-            case 4 -> {
-                String devicePublicKey = Base64.getEncoder().encodeToString(KEY_CONVERTOR_EC.convertPublicKeyToBytes(EcCurve.P384, devicePublicKeyObject));
-                jsonObject.put("ecDevicePublicKey", devicePublicKey);
-            }
-            default -> throw new IllegalStateException("Unsupported version: " + version);
-        }
+        String devicePublicKey = Base64.getEncoder().encodeToString(KEY_CONVERTOR_EC.convertPublicKeyToBytes(EcCurve.P384, devicePublicKeyObject));
+        jsonObject.put("ecDevicePublicKey", devicePublicKey);
     }
 
     /**
      * @return Base64 encoded byte representation of the EC device public key
      */
     public String getEcDevicePublicKey() {
-        int version = getVersion().intValue();
-        return switch (version) {
-            case 3 -> (String) jsonObject.get("devicePublicKey");
-            case 4 -> (String) jsonObject.get("ecDevicePublicKey");
-            default -> throw new IllegalStateException("Unsupported version: " + version);
-        };
+        return (String) jsonObject.get("ecDevicePublicKey");
     }
 
     /**
@@ -383,12 +307,7 @@ public class ResultStatusObject {
      * @param devicePublicKey Public key as base64
      */
     public void setEcDevicePublicKey(String devicePublicKey) {
-        int version = getVersion().intValue();
-        switch (version) {
-            case 3 -> jsonObject.put("devicePublicKey", devicePublicKey);
-            case 4 -> jsonObject.put("ecDevicePublicKey", devicePublicKey);
-            default -> throw new IllegalStateException("Unsupported version: " + version);
-        }
+        jsonObject.put("ecDevicePublicKey", devicePublicKey);
     }
 
     /**
@@ -435,12 +354,7 @@ public class ResultStatusObject {
      */
     @JsonIgnore
     public SecretKey getBiometryFactorKeyObject() {
-        final String biometryFactorKey;
-        switch (getVersion().intValue()) {
-            case 3 -> biometryFactorKey = (String) jsonObject.get("signatureBiometryKey");
-            case 4 -> biometryFactorKey = (String) jsonObject.get("biometryFactorKey");
-            default -> throw new IllegalStateException("Unsupported version: " + getVersion());
-        }
+        final String biometryFactorKey = (String) jsonObject.get("biometryFactorKey");
         if (biometryFactorKey == null) {
             return null;
         }
@@ -456,21 +370,14 @@ public class ResultStatusObject {
         final String biometryFactorKey = biometryFactorKeyObject != null
                 ? Base64.getEncoder().encodeToString(KEY_CONVERTOR_EC.convertSharedSecretKeyToBytes(biometryFactorKeyObject))
                 : null;
-        switch (getVersion().intValue()) {
-            case 3 -> jsonObject.put("signatureBiometryKey", biometryFactorKey);
-            case 4 -> jsonObject.put("biometryFactorKey", biometryFactorKey);
-        }
+        jsonObject.put("biometryFactorKey", biometryFactorKey);
     }
 
     /**
      * @return Base64 encoded byte representation of the biometry factor key
      */
     public String getBiometryFactorKey() {
-        return switch (getVersion().intValue()) {
-            case 3 -> (String) jsonObject.get("signatureBiometryKey");
-            case 4 -> (String) jsonObject.get("biometryFactorKey");
-            default -> throw new IllegalStateException("Unsupported version: " + getVersion());
-        };
+        return (String) jsonObject.get("biometryFactorKey");
     }
 
     /**
@@ -478,11 +385,7 @@ public class ResultStatusObject {
      * @param biometryFactorKey Biometry factor key
      */
     public void setBiometryFactorKey(String biometryFactorKey) {
-        switch (getVersion().intValue()) {
-            case 3 -> jsonObject.put("signatureBiometryKey", biometryFactorKey);
-            case 4 -> jsonObject.put("biometryFactorKey", biometryFactorKey);
-            default -> throw new IllegalStateException("Unsupported version: " + getVersion());
-        }
+        jsonObject.put("biometryFactorKey", biometryFactorKey);
     }
 
     /**
@@ -490,12 +393,7 @@ public class ResultStatusObject {
      */
     @JsonIgnore
     public byte[] getKnowledgeFactorKeyEncryptedBytes() {
-        String knowledgeFactorKeyEncrypted;
-        switch (getVersion().intValue()) {
-            case 3 -> knowledgeFactorKeyEncrypted = (String) jsonObject.get("signatureKnowledgeKeyEncrypted");
-            case 4 -> knowledgeFactorKeyEncrypted = (String) jsonObject.get("knowledgeFactorKeyEncrypted");
-            default -> throw new IllegalStateException("Unsupported version: " + getVersion());
-        }
+        final String knowledgeFactorKeyEncrypted = (String) jsonObject.get("knowledgeFactorKeyEncrypted");
         return Base64.getDecoder().decode(knowledgeFactorKeyEncrypted);
     }
 
@@ -505,23 +403,15 @@ public class ResultStatusObject {
      */
     @JsonIgnore
     public void setKnowledgeFactorKeyEncryptedBytes(byte[] knowledgeFactorKeyEncryptedBytes) {
-        String knowledgeFactorKeyEncrypted = Base64.getEncoder().encodeToString(knowledgeFactorKeyEncryptedBytes);
-        switch (getVersion().intValue()) {
-            case 3 -> jsonObject.put("signatureKnowledgeKeyEncrypted", knowledgeFactorKeyEncrypted);
-            case 4 -> jsonObject.put("knowledgeFactorKeyEncrypted", knowledgeFactorKeyEncrypted);
-            default -> throw new IllegalStateException("Unsupported version: " + getVersion());
-        }
+        final String knowledgeFactorKeyEncrypted = Base64.getEncoder().encodeToString(knowledgeFactorKeyEncryptedBytes);
+        jsonObject.put("knowledgeFactorKeyEncrypted", knowledgeFactorKeyEncrypted);
     }
 
     /**
      * @return Base64 encoded byte representation of the knowledge factor key
      */
     public String getKnowledgeFactorKeyEncrypted() {
-        return switch (getVersion().intValue()) {
-            case 3 -> (String) jsonObject.get("signatureKnowledgeKeyEncrypted");
-            case 4 -> (String) jsonObject.get("knowledgeFactorKeyEncrypted");
-            default -> throw new IllegalStateException("Unsupported version: " + getVersion());
-        };
+        return (String) jsonObject.get("knowledgeFactorKeyEncrypted");
     }
 
     /**
@@ -529,11 +419,7 @@ public class ResultStatusObject {
      * @param knowledgeFactorKeyEncrypted Knowledge factor key encrypted value
      */
     public void setKnowledgeFactorKeyEncrypted(String knowledgeFactorKeyEncrypted) {
-        switch (getVersion().intValue()) {
-            case 3 -> jsonObject.put("signatureKnowledgeKeyEncrypted", knowledgeFactorKeyEncrypted);
-            case 4 -> jsonObject.put("knowledgeFactorKeyEncrypted", knowledgeFactorKeyEncrypted);
-            default -> throw new IllegalStateException("Unsupported version: " + getVersion());
-        }
+        jsonObject.put("knowledgeFactorKeyEncrypted", knowledgeFactorKeyEncrypted);
     }
 
     /**
@@ -541,12 +427,7 @@ public class ResultStatusObject {
      */
     @JsonIgnore
     public byte[] getKnowledgeFactorKeySaltBytes() {
-        String knowledgeFactorKeySalt;
-        switch (getVersion().intValue()) {
-            case 3 -> knowledgeFactorKeySalt = (String) jsonObject.get("signatureKnowledgeKeySalt");
-            case 4 -> knowledgeFactorKeySalt = (String) jsonObject.get("knowledgeFactorKeySalt");
-            default -> throw new IllegalStateException("Unsupported version: " + getVersion());
-        }
+        final String knowledgeFactorKeySalt = (String) jsonObject.get("knowledgeFactorKeySalt");
         return Base64.getDecoder().decode(knowledgeFactorKeySalt);
     }
 
@@ -556,23 +437,15 @@ public class ResultStatusObject {
      */
     @JsonIgnore
     public void setKnowledgeFactorKeySaltBytes(byte[] knowledgeFactorKeySaltBytes) {
-        String knowledgeFactorKeySalt = Base64.getEncoder().encodeToString(knowledgeFactorKeySaltBytes);
-        switch (getVersion().intValue()) {
-            case 3 -> jsonObject.put("signatureKnowledgeKeySalt", knowledgeFactorKeySalt);
-            case 4 -> jsonObject.put("knowledgeFactorKeySalt", knowledgeFactorKeySalt);
-            default -> throw new IllegalStateException("Unsupported version: " + getVersion());
-        }
+        final String knowledgeFactorKeySalt = Base64.getEncoder().encodeToString(knowledgeFactorKeySaltBytes);
+        jsonObject.put("knowledgeFactorKeySalt", knowledgeFactorKeySalt);
     }
 
     /**
      * @return Knowledge factor salt
      */
     public String getKnowledgeFactorKeySalt() {
-        return switch (getVersion().intValue()) {
-            case 3 -> (String) jsonObject.get("signatureKnowledgeKeySalt");
-            case 4 -> (String) jsonObject.get("knowledgeFactorKeySalt");
-            default -> throw new IllegalStateException("Unsupported version: " + getVersion());
-        };
+        return (String) jsonObject.get("knowledgeFactorKeySalt");
     }
 
     /**
@@ -580,11 +453,7 @@ public class ResultStatusObject {
      * @param knowledgeFactorKeySalt Knowledge factor key salt value
      */
     public void setKnowledgeFactorKeySalt(String knowledgeFactorKeySalt) {
-        switch (getVersion().intValue()) {
-            case 3 -> jsonObject.put("signatureKnowledgeKeySalt", knowledgeFactorKeySalt);
-            case 4 -> jsonObject.put("knowledgeFactorKeySalt", knowledgeFactorKeySalt);
-            default -> throw new IllegalStateException("Unsupported version: " + getVersion());
-        }
+        jsonObject.put("knowledgeFactorKeySalt", knowledgeFactorKeySalt);
     }
 
     /**
@@ -592,12 +461,7 @@ public class ResultStatusObject {
      */
     @JsonIgnore
     public SecretKey getPossessionFactorKeyObject() {
-        final String possessionFactorKey;
-        switch (getVersion().intValue()) {
-            case 3 -> possessionFactorKey = (String) jsonObject.get("signaturePossessionKey");
-            case 4 -> possessionFactorKey = (String) jsonObject.get("possessionFactorKey");
-            default -> throw new IllegalStateException("Unsupported version: " + getVersion());
-        }
+        final String possessionFactorKey = (String) jsonObject.get("possessionFactorKey");
         if (possessionFactorKey == null) {
             return null;
         }
@@ -610,23 +474,15 @@ public class ResultStatusObject {
      */
     @JsonIgnore
     public void setPossessionFactorKeyObject(SecretKey possessionFactorKeyObject) {
-        String possessionFactorKey = Base64.getEncoder().encodeToString(KEY_CONVERTOR_EC.convertSharedSecretKeyToBytes(possessionFactorKeyObject));
-        switch (getVersion().intValue()) {
-            case 3 -> jsonObject.put("signaturePossessionKey", possessionFactorKey);
-            case 4 -> jsonObject.put("possessionFactorKey", possessionFactorKey);
-            default -> throw new IllegalStateException("Unsupported version: " + getVersion());
-        }
+        final String possessionFactorKey = Base64.getEncoder().encodeToString(KEY_CONVERTOR_EC.convertSharedSecretKeyToBytes(possessionFactorKeyObject));
+        jsonObject.put("possessionFactorKey", possessionFactorKey);
     }
 
     /**
      * @return Base64 encoded byte representation of the possession factor key
      */
     public String getPossessionFactorKey() {
-        return switch (getVersion().intValue()) {
-            case 3 -> (String) jsonObject.get("signaturePossessionKey");
-            case 4 -> (String) jsonObject.get("possessionFactorKey");
-            default -> throw new IllegalStateException("Unsupported version: " + getVersion());
-        };
+        return (String) jsonObject.get("possessionFactorKey");
     }
 
     /**
@@ -634,11 +490,7 @@ public class ResultStatusObject {
      * @param possessionFactorKey Base64 encoded byte representation of the possession factor key
      */
     public void setPossessionFactorKey(String possessionFactorKey) {
-        switch (getVersion().intValue()) {
-            case 3 -> jsonObject.put("signaturePossessionKey", possessionFactorKey);
-            case 4 -> jsonObject.put("possessionFactorKey", possessionFactorKey);
-            default -> throw new IllegalStateException("Unsupported version: " + getVersion());
-        }
+        jsonObject.put("possessionFactorKey", possessionFactorKey);
     }
 
     /**

--- a/powerauth-java-cmd-lib/src/main/java/com/wultra/security/powerauth/lib/cmd/steps/pojo/ResultStatusObject.java
+++ b/powerauth-java-cmd-lib/src/main/java/com/wultra/security/powerauth/lib/cmd/steps/pojo/ResultStatusObject.java
@@ -105,37 +105,92 @@ public class ResultStatusObject {
     }
 
     /**
-     * @return Byte representation of the encrypted device private key
+     * @return Byte representation of the encrypted EC device private key
      */
     @JsonIgnore
-    public byte[] getEncryptedDevicePrivateKeyBytes() {
-        String encryptedDevicePrivateKey = (String) jsonObject.get("encryptedDevicePrivateKey");
+    public byte[] getEncryptedEcDevicePrivateKeyBytes() {
+        final int version = getVersion().intValue();
+        final String encryptedDevicePrivateKey = switch (version) {
+            case 3 -> (String) jsonObject.get("encryptedDevicePrivateKey");
+            case 4 -> (String) jsonObject.get("encryptedEcDevicePrivateKey");
+            default -> throw new IllegalStateException("Unsupported version: " + version);
+        };
+        if (encryptedDevicePrivateKey == null) {
+            return null;
+        }
         return Base64.getDecoder().decode(encryptedDevicePrivateKey);
     }
 
     /**
-     * Sets encrypted device private key
-     * @param encryptedDevicePrivateKeyBytes Encrypted device private key bytes
+     * Sets encrypted EC device private key
+     * @param encryptedDevicePrivateKeyBytes Encrypted EC device private key bytes
      */
     @JsonIgnore
-    public void setEncryptedDevicePrivateKeyBytes(byte[] encryptedDevicePrivateKeyBytes) {
-        String encryptedDevicePrivateKey = Base64.getEncoder().encodeToString(encryptedDevicePrivateKeyBytes);
-        jsonObject.put("encryptedDevicePrivateKey", encryptedDevicePrivateKey);
+    public void setEncryptedEcDevicePrivateKeyBytes(byte[] encryptedDevicePrivateKeyBytes) {
+        final int version = getVersion().intValue();
+        final String encryptedDevicePrivateKey = Base64.getEncoder().encodeToString(encryptedDevicePrivateKeyBytes);
+        switch (version) {
+            case 3 -> jsonObject.put("encryptedDevicePrivateKey", encryptedDevicePrivateKey);
+            case 4 -> jsonObject.put("encryptedEcDevicePrivateKey", encryptedDevicePrivateKey);
+            default -> throw new IllegalStateException("Unsupported version: " + version);
+        }
     }
 
     /**
-     * @return Base64 encoded byte representation of the encrypted device private key
+     * @return Base64 encoded byte representation of the encrypted EC device private key
      */
-    public String getEncryptedDevicePrivateKey() {
-        return (String) jsonObject.get("encryptedDevicePrivateKey");
+    public String getEncryptedEcDevicePrivateKey() {
+        return (String) jsonObject.get("encryptedEcDevicePrivateKey");
     }
 
     /**
-     * Sets encrypted device private key object
-     * @param encryptedDevicePrivateKey Encrypted device private key object
+     * Sets encrypted PQC device private key object
+     * @param encryptedDevicePrivateKey Encrypted PQC device private key object
      */
-    public void setEncryptedDevicePrivateKey(String encryptedDevicePrivateKey) {
-        jsonObject.put("encryptedDevicePrivateKey", encryptedDevicePrivateKey);
+    public void setEncryptedEcDevicePrivateKey(String encryptedDevicePrivateKey) {
+        jsonObject.put("encryptedEcDevicePrivateKey", encryptedDevicePrivateKey);
+    }
+
+    /**
+     * @return Byte representation of the encrypted PQC device private key
+     */
+    @JsonIgnore
+    public byte[] getEncryptedPqcDevicePrivateKeyBytes() {
+        final String encryptedDevicePrivateKey = (String) jsonObject.get("encryptedPqcDevicePrivateKey");
+        if (encryptedDevicePrivateKey == null) {
+            return null;
+        }
+        return Base64.getDecoder().decode(encryptedDevicePrivateKey);
+    }
+
+    /**
+     * Sets encrypted PQC device private key
+     * @param encryptedDevicePrivateKeyBytes Encrypted PQC device private key bytes
+     */
+    @JsonIgnore
+    public void setEncryptedPqcDevicePrivateKeyBytes(byte[] encryptedDevicePrivateKeyBytes) {
+        final String encryptedDevicePrivateKey = Base64.getEncoder().encodeToString(encryptedDevicePrivateKeyBytes);
+        jsonObject.put("encryptedPqcDevicePrivateKey", encryptedDevicePrivateKey);
+    }
+
+    /**
+     * @return Base64 encoded byte representation of the encrypted EC device private key
+     */
+    public String getEncryptedPqcDevicePrivateKey() {
+        return (String) jsonObject.get("encryptedPqcDevicePrivateKey");
+    }
+
+    /**
+     * Sets encrypted EC device private key object
+     * @param encryptedDevicePrivateKey Encrypted EC device private key object
+     */
+    public void setEncryptedPqcDevicePrivateKey(String encryptedDevicePrivateKey) {
+        final int version = getVersion().intValue();
+        switch (version) {
+            case 3 -> jsonObject.put("encryptedDevicePrivateKey", encryptedDevicePrivateKey);
+            case 4 -> jsonObject.put("encryptedPqcDevicePrivateKey", encryptedDevicePrivateKey);
+            default -> throw new IllegalStateException("Unsupported version: " + version);
+        }
     }
 
     /**

--- a/powerauth-java-cmd/src/main/java/com/wultra/security/powerauth/app/cmd/Application.java
+++ b/powerauth-java-cmd/src/main/java/com/wultra/security/powerauth/app/cmd/Application.java
@@ -570,6 +570,25 @@ public class Application {
 
                     stepExecutionService.execute(powerAuthStep, version, model);
                 }
+                case SIGN_ASYMMETRIC -> {
+                    final SignAsymmetricStepModel model = new SignAsymmetricStepModel();
+                    model.setApplicationKey(applicationKey);
+                    model.setApplicationSecret(applicationSecret);
+                    model.setHeaders(httpHeaders);
+                    model.setPassword(cmd.getOptionValue("p"));
+                    model.setResultStatus(resultStatusObject);
+                    model.setStatusFileName(statusFileName);
+                    model.setAuthenticationCodeType(PowerAuthCodeType.getEnumFromString(cmd.getOptionValue("l")));
+                    model.setUriString(uriString);
+                    model.setVersion(version);
+
+                    // Read the file with request data
+                    String dataFileName = cmd.getOptionValue("d");
+                    final byte[] dataFileBytes = FileUtil.readFileBytes(stepLogger, dataFileName, "request-data", "Request data file");
+                    model.setData(dataFileBytes);
+
+                    stepExecutionService.execute(powerAuthStep, version, model);
+                }
 
                 default -> {
                     System.err.println("Not recognized PowerAuth step: " + powerAuthStep);


### PR DESCRIPTION
This pull request introduces a step for signing request data using device private keys.

Note that the pull request also contains its prerequisites which can be reviewed seprately:
https://github.com/wultra/powerauth-cmd-tool/pull/581