### PR TITLE
Fix #625: Null pointer exception when accessing old keys

### DIFF
--- a/powerauth-java-cmd-lib/src/main/java/com/wultra/security/powerauth/lib/cmd/header/AuthorizationHeaderProvider.java
+++ b/powerauth-java-cmd-lib/src/main/java/com/wultra/security/powerauth/lib/cmd/header/AuthorizationHeaderProvider.java
@@ -85,6 +85,9 @@ public class AuthorizationHeaderProvider implements PowerAuthHeaderProvider<Auth
             final SecretKey knowledgeFactorKey = getKnowledgeKeyFactor(model);
             authSecretKeys = Arrays.asList(possessionFactorKey, knowledgeFactorKey);
         } else {
+            if (biometryFactorKey == null) {
+                throw new IllegalStateException("Missing biometry factor key");
+            }
             final SecretKey knowledgeFactorKey = getKnowledgeKeyFactor(model);
             authSecretKeys = KEY_FACTORY.keysForAuthenticationCodeType(model.getAuthenticationCodeType(), possessionFactorKey, knowledgeFactorKey, biometryFactorKey);
         }

--- a/powerauth-java-cmd-lib/src/main/java/com/wultra/security/powerauth/lib/cmd/header/AuthorizationHeaderProvider.java
+++ b/powerauth-java-cmd-lib/src/main/java/com/wultra/security/powerauth/lib/cmd/header/AuthorizationHeaderProvider.java
@@ -85,9 +85,6 @@ public class AuthorizationHeaderProvider implements PowerAuthHeaderProvider<Auth
             final SecretKey knowledgeFactorKey = getKnowledgeKeyFactor(model);
             authSecretKeys = Arrays.asList(possessionFactorKey, knowledgeFactorKey);
         } else {
-            if (biometryFactorKey == null) {
-                throw new IllegalStateException("Missing biometry factor key");
-            }
             final SecretKey knowledgeFactorKey = getKnowledgeKeyFactor(model);
             authSecretKeys = KEY_FACTORY.keysForAuthenticationCodeType(model.getAuthenticationCodeType(), possessionFactorKey, knowledgeFactorKey, biometryFactorKey);
         }

--- a/powerauth-java-cmd-lib/src/main/java/com/wultra/security/powerauth/lib/cmd/steps/ComputeOfflineAuthenticationStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/com/wultra/security/powerauth/lib/cmd/steps/ComputeOfflineAuthenticationStep.java
@@ -218,9 +218,6 @@ public class ComputeOfflineAuthenticationStep extends AbstractBaseStep<ComputeOf
                     final byte[] kmacData = (offlineDataWithoutSignature.getBytes(StandardCharsets.UTF_8));
 
                     final SecretKey keyMacPersonalisedData = resultStatusObject.getMacPersonalizedDataKeyObject();
-                    if (keyMacPersonalisedData == null) {
-                        throw new IllegalStateException("The macPersonalizedDataKey is missing");
-                    }
 
                     // Construct KMAC-256 tag
                     final byte[] tagKmac = Kmac.kmac256(keyMacPersonalisedData, kmacData, KMAC_OFFLINE_SIGNATURE_CUSTOM_BYTES, 32);

--- a/powerauth-java-cmd-lib/src/main/java/com/wultra/security/powerauth/lib/cmd/steps/GetStatusStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/com/wultra/security/powerauth/lib/cmd/steps/GetStatusStep.java
@@ -181,9 +181,6 @@ public class GetStatusStep extends AbstractBaseStep<GetStatusStepModel, Object> 
                 byte[] challenge = (byte[]) stepContext.getAttributes().get(ATTRIBUTE_CHALLENGE);
 
                 final SecretKey transportMasterKey = resultStatusObject.getTransportMasterKeyObject();
-                if (transportMasterKey == null) {
-                    throw new IllegalStateException("The transportMasterKey is missing");
-                }
 
                 final ActivationStatusBlobInfo statusBlobRaw = CLIENT_ACTIVATION_V3.getStatusFromEncryptedBlob(cStatusBlob, challenge, cStatusBlobNonce, transportMasterKey);
                 statusBlobInfo = ExtendedActivationStatusBlobInfo.copy(statusBlobRaw);
@@ -200,9 +197,6 @@ public class GetStatusStep extends AbstractBaseStep<GetStatusStepModel, Object> 
                 final byte[] statusBlobData = Arrays.copyOfRange(statusBlob, 0, 48);
                 final byte[] statusBlobMac = Arrays.copyOfRange(statusBlob, 48, 80);
                 final SecretKey statusBlobMacKey = resultStatusObject.getStatusBlobMacKeyObject();
-                if (statusBlobMacKey == null) {
-                    throw new IllegalStateException("The statusBlobMacKey is missing");
-                }
                 // Verify MAC
                 if (!CLIENT_ACTIVATION_V4.verifyStatusMac(statusBlobData, statusBlobMac, statusBlobMacKey, ProtocolVersion.fromValue(stepContext.getModel().getVersion().value()))) {
                     throw new GenericCryptoException("Failed MAC verification for status blob");

--- a/powerauth-java-cmd-lib/src/main/java/com/wultra/security/powerauth/lib/cmd/steps/SignAsymmetricStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/com/wultra/security/powerauth/lib/cmd/steps/SignAsymmetricStep.java
@@ -24,6 +24,7 @@ import com.wultra.security.powerauth.crypto.lib.util.KeyConvertor;
 import com.wultra.security.powerauth.crypto.lib.util.SignatureUtils;
 import com.wultra.security.powerauth.crypto.lib.v4.api.PqcDsa;
 import com.wultra.security.powerauth.crypto.lib.v4.ml.MlDsa;
+import com.wultra.security.powerauth.crypto.lib.v4.model.context.SharedSecretAlgorithm;
 import com.wultra.security.powerauth.lib.cmd.consts.BackwardCompatibilityConst;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthStep;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
@@ -223,7 +224,8 @@ public class SignAsymmetricStep extends AbstractBaseStep<SignAsymmetricStepModel
                 final byte[] signatureEc = SIGNATURE_UTILS.computeECDSASignature(EcCurve.P384, requestDataBytes, ecDevicePrivateKey);
                 objectMap.put("signatureEc", Base64.getEncoder().encodeToString(signatureEc));
 
-                if (resultStatusObject.getEncryptedPqcDevicePrivateKey() != null) {
+                if (resultStatusObject.getSharedSecretAlgorithm().equals(SharedSecretAlgorithm.EC_P384_ML_L3.name())
+                    || resultStatusObject.getSharedSecretAlgorithm().equals(SharedSecretAlgorithm.EC_P384_ML_L5.name())) {
                     final byte[] encryptedPqcDevicePrivateKeyBytes = Base64.getDecoder().decode(resultStatusObject.getEncryptedPqcDevicePrivateKey());
                     final PrivateKey pqcDevicePrivateKey = VAULT_V4.decryptPqcDevicePrivateKey(encryptedPqcDevicePrivateKeyBytes, vaultUnlockKekDevicePrivate);
                     final byte[] signaturePqc = PQC_DSA.sign(pqcDevicePrivateKey, requestDataBytes);

--- a/powerauth-java-cmd-lib/src/main/java/com/wultra/security/powerauth/lib/cmd/steps/VaultUnlockStep.java
+++ b/powerauth-java-cmd-lib/src/main/java/com/wultra/security/powerauth/lib/cmd/steps/VaultUnlockStep.java
@@ -22,6 +22,7 @@ import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorScope;
 import com.wultra.security.powerauth.crypto.lib.util.KeyConvertor;
 import com.wultra.security.powerauth.crypto.lib.v4.api.PqcDsaKeyConvertor;
 import com.wultra.security.powerauth.crypto.lib.v4.ml.MlDsaKeyConvertor;
+import com.wultra.security.powerauth.crypto.lib.v4.model.context.SharedSecretAlgorithm;
 import com.wultra.security.powerauth.lib.cmd.consts.BackwardCompatibilityConst;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthStep;
 import com.wultra.security.powerauth.lib.cmd.consts.PowerAuthVersion;
@@ -216,7 +217,8 @@ public class VaultUnlockStep extends AbstractBaseStep<VaultUnlockStepModel, Encr
                     final byte[] encryptedEcDevicePrivateKeyBytes = resultStatusObject.getEncryptedEcDevicePrivateKeyBytes();
                     final PrivateKey ecDevicePrivateKey = VAULT_V4.decryptEcDevicePrivateKey(encryptedEcDevicePrivateKeyBytes, vaultUnlockKekDevicePrivate);
                     objectMap.put("deviceEcPrivateKey", Base64.getEncoder().encodeToString(KEY_CONVERTOR_EC.convertPrivateKeyToBytes(ecDevicePrivateKey)));
-                    if (resultStatusObject.getEncryptedPqcDevicePrivateKey() != null) {
+                    if (resultStatusObject.getSharedSecretAlgorithm().equals(SharedSecretAlgorithm.EC_P384_ML_L3.name())
+                            || resultStatusObject.getSharedSecretAlgorithm().equals(SharedSecretAlgorithm.EC_P384_ML_L5.name())) {
                         final byte[] encryptedPqcDevicePrivateKeyBytes = resultStatusObject.getEncryptedPqcDevicePrivateKeyBytes();
                         final PrivateKey pqcDevicePrivateKey = VAULT_V4.decryptPqcDevicePrivateKey(encryptedPqcDevicePrivateKeyBytes, vaultUnlockKekDevicePrivate);
                         objectMap.put("devicePqcPrivateKey", Base64.getEncoder().encodeToString(KEY_CONVERTOR_PQC.convertPrivateKeyToBytes(pqcDevicePrivateKey)));

--- a/powerauth-java-cmd-lib/src/main/java/com/wultra/security/powerauth/lib/cmd/steps/pojo/ResultStatusObject.java
+++ b/powerauth-java-cmd-lib/src/main/java/com/wultra/security/powerauth/lib/cmd/steps/pojo/ResultStatusObject.java
@@ -111,10 +111,7 @@ public class ResultStatusObject {
      */
     @JsonIgnore
     public byte[] getEncryptedEcDevicePrivateKeyBytes() {
-        final String encryptedDevicePrivateKey = (String) jsonObject.get("encryptedEcDevicePrivateKey");
-        if (encryptedDevicePrivateKey == null) {
-            return null;
-        }
+        final String encryptedDevicePrivateKey = getEncryptedEcDevicePrivateKey();
         return Base64.getDecoder().decode(encryptedDevicePrivateKey);
     }
 
@@ -132,12 +129,16 @@ public class ResultStatusObject {
      * @return Base64 encoded byte representation of the encrypted EC device private key
      */
     public String getEncryptedEcDevicePrivateKey() {
-        return (String) jsonObject.get("encryptedEcDevicePrivateKey");
+        final String encryptedEcDevicePrivateKey = (String) jsonObject.get("encryptedEcDevicePrivateKey");
+        if (encryptedEcDevicePrivateKey == null) {
+            throw new IllegalStateException("Encrypted EC device private key is missing.");
+        }
+        return encryptedEcDevicePrivateKey;
     }
 
     /**
-     * Sets encrypted PQC device private key object
-     * @param encryptedDevicePrivateKey Encrypted PQC device private key object
+     * Sets encrypted EC device private key object
+     * @param encryptedDevicePrivateKey Encrypted EC device private key object
      */
     public void setEncryptedEcDevicePrivateKey(String encryptedDevicePrivateKey) {
         jsonObject.put("encryptedEcDevicePrivateKey", encryptedDevicePrivateKey);
@@ -148,10 +149,7 @@ public class ResultStatusObject {
      */
     @JsonIgnore
     public byte[] getEncryptedPqcDevicePrivateKeyBytes() {
-        final String encryptedDevicePrivateKey = (String) jsonObject.get("encryptedPqcDevicePrivateKey");
-        if (encryptedDevicePrivateKey == null) {
-            return null;
-        }
+        final String encryptedDevicePrivateKey = getEncryptedPqcDevicePrivateKey();
         return Base64.getDecoder().decode(encryptedDevicePrivateKey);
     }
 
@@ -169,12 +167,16 @@ public class ResultStatusObject {
      * @return Base64 encoded byte representation of the encrypted EC device private key
      */
     public String getEncryptedPqcDevicePrivateKey() {
-        return (String) jsonObject.get("encryptedPqcDevicePrivateKey");
+        final String encryptedPqcDevicePrivateKey = (String) jsonObject.get("encryptedPqcDevicePrivateKey");
+        if (encryptedPqcDevicePrivateKey == null) {
+            throw new IllegalStateException("Encrypted PQC device private key is missing.");
+        }
+        return encryptedPqcDevicePrivateKey;
     }
 
     /**
-     * Sets encrypted EC device private key object
-     * @param encryptedDevicePrivateKey Encrypted EC device private key object
+     * Sets encrypted PQC device private key
+     * @param encryptedDevicePrivateKey Encrypted PQC device private key
      */
     public void setEncryptedPqcDevicePrivateKey(String encryptedDevicePrivateKey) {
         jsonObject.put("encryptedPqcDevicePrivateKey", encryptedDevicePrivateKey);
@@ -201,10 +203,7 @@ public class ResultStatusObject {
      */
     @JsonIgnore
     public PublicKey getEcServerPublicKeyObject() throws Exception {
-        String serverPublicKey = (String) jsonObject.get("ecServerPublicKey");
-        if (serverPublicKey == null) {
-            return null;
-        }
+        final String serverPublicKey = getEcServerPublicKey();
         return KEY_CONVERTOR_EC.convertBytesToPublicKey(resolveEcCurve(), Base64.getDecoder().decode(serverPublicKey));
     }
 
@@ -215,8 +214,7 @@ public class ResultStatusObject {
      */
     @JsonIgnore
     public void setEcServerPublicKeyObject(PublicKey serverPublicKeyObject) throws CryptoProviderException {
-
-        String serverPublicKey = Base64.getEncoder().encodeToString(KEY_CONVERTOR_EC.convertPublicKeyToBytes(resolveEcCurve(), serverPublicKeyObject));
+        final String serverPublicKey = Base64.getEncoder().encodeToString(KEY_CONVERTOR_EC.convertPublicKeyToBytes(resolveEcCurve(), serverPublicKeyObject));
         jsonObject.put("ecServerPublicKey", serverPublicKey);
     }
 
@@ -224,7 +222,11 @@ public class ResultStatusObject {
      * @return Base64 encoded byte representation of the EC server public key
      */
     public String getEcServerPublicKey() {
-        return (String) jsonObject.get("ecServerPublicKey");
+        final String ecServerPublicKey = (String) jsonObject.get("ecServerPublicKey");
+        if (ecServerPublicKey == null) {
+            throw new IllegalStateException("EC server public key is missing.");
+        }
+        return ecServerPublicKey;
     }
 
     /**
@@ -241,11 +243,8 @@ public class ResultStatusObject {
      */
     @JsonIgnore
     public PublicKey getPqcServerPublicKeyObject() throws Exception {
-        String serverPublicKey = (String) jsonObject.get("pqcServerPublicKey");
-        if (serverPublicKey == null) {
-            return null;
-        }
-        return KEY_CONVERTOR_PQC_DSA.convertBytesToPublicKey(Base64.getDecoder().decode(serverPublicKey));
+        final String pqcServerPublicKey = getPqcServerPublicKey();
+        return KEY_CONVERTOR_PQC_DSA.convertBytesToPublicKey(Base64.getDecoder().decode(pqcServerPublicKey));
     }
 
     /**
@@ -255,7 +254,7 @@ public class ResultStatusObject {
      */
     @JsonIgnore
     public void setPqcServerPublicKeyObject(PublicKey serverPublicKeyObject) throws Exception {
-        String serverPublicKey = Base64.getEncoder().encodeToString(KEY_CONVERTOR_PQC_DSA.convertPublicKeyToBytes(serverPublicKeyObject));
+        final String serverPublicKey = Base64.getEncoder().encodeToString(KEY_CONVERTOR_PQC_DSA.convertPublicKeyToBytes(serverPublicKeyObject));
         jsonObject.put("pqcServerPublicKey", serverPublicKey);
     }
 
@@ -263,7 +262,11 @@ public class ResultStatusObject {
      * @return Base64 encoded byte representation of the PQC server public key
      */
     public String getPqcServerPublicKey() {
-        return (String) jsonObject.get("pqcServerPublicKey");
+        final String pqcServerPublicKey = (String) jsonObject.get("pqcServerPublicKey");
+        if (pqcServerPublicKey == null) {
+            throw new IllegalStateException("PQC server public key is missing.");
+        }
+        return pqcServerPublicKey;
     }
 
     /**
@@ -280,11 +283,8 @@ public class ResultStatusObject {
      */
     @JsonIgnore
     public PublicKey getEcDevicePublicKeyObject() throws Exception {
-        String devicePublicKey = (String) jsonObject.get("ecDevicePublicKey");
-        if (devicePublicKey == null) {
-            return null;
-        }
-        return KEY_CONVERTOR_EC.convertBytesToPublicKey(resolveEcCurve(), Base64.getDecoder().decode(devicePublicKey));
+        final String ecDevicePublicKey = getEcDevicePublicKey();
+        return KEY_CONVERTOR_EC.convertBytesToPublicKey(resolveEcCurve(), Base64.getDecoder().decode(ecDevicePublicKey));
     }
 
     /**
@@ -294,7 +294,7 @@ public class ResultStatusObject {
      */
     @JsonIgnore
     public void setEcDevicePublicKeyObject(PublicKey devicePublicKeyObject) throws CryptoProviderException {
-        String devicePublicKey = Base64.getEncoder().encodeToString(KEY_CONVERTOR_EC.convertPublicKeyToBytes(resolveEcCurve(), devicePublicKeyObject));
+        final String devicePublicKey = Base64.getEncoder().encodeToString(KEY_CONVERTOR_EC.convertPublicKeyToBytes(resolveEcCurve(), devicePublicKeyObject));
         jsonObject.put("ecDevicePublicKey", devicePublicKey);
     }
 
@@ -302,7 +302,11 @@ public class ResultStatusObject {
      * @return Base64 encoded byte representation of the EC device public key
      */
     public String getEcDevicePublicKey() {
-        return (String) jsonObject.get("ecDevicePublicKey");
+        final String ecDevicePublicKey = (String) jsonObject.get("ecDevicePublicKey");
+        if (ecDevicePublicKey == null) {
+            throw new IllegalStateException("EC device public key is missing.");
+        }
+        return ecDevicePublicKey;
     }
 
     /**
@@ -319,11 +323,8 @@ public class ResultStatusObject {
      */
     @JsonIgnore
     public PublicKey getPqcDevicePublicKeyObject() throws Exception {
-        String devicePublicKey = (String) jsonObject.get("pqcDevicePublicKey");
-        if (devicePublicKey == null) {
-            return null;
-        }
-        return KEY_CONVERTOR_PQC_DSA.convertBytesToPublicKey(Base64.getDecoder().decode(devicePublicKey));
+        final String pqcDevicePublicKey = getPqcDevicePublicKey();
+        return KEY_CONVERTOR_PQC_DSA.convertBytesToPublicKey(Base64.getDecoder().decode(pqcDevicePublicKey));
     }
 
     /**
@@ -333,7 +334,7 @@ public class ResultStatusObject {
      */
     @JsonIgnore
     public void setPqcDevicePublicKeyObject(PublicKey devicePublicKeyObject) throws GenericCryptoException {
-        String devicePublicKey = Base64.getEncoder().encodeToString(KEY_CONVERTOR_PQC_DSA.convertPublicKeyToBytes(devicePublicKeyObject));
+        final String devicePublicKey = Base64.getEncoder().encodeToString(KEY_CONVERTOR_PQC_DSA.convertPublicKeyToBytes(devicePublicKeyObject));
         jsonObject.put("pqcDevicePublicKey", devicePublicKey);
     }
 
@@ -341,7 +342,11 @@ public class ResultStatusObject {
      * @return Base64 encoded byte representation of the PQC device public key
      */
     public String getPqcDevicePublicKey() {
-        return (String) jsonObject.get("pqcDevicePublicKey");
+        final String pqcDevicePublicKey = (String) jsonObject.get("pqcDevicePublicKey");
+        if (pqcDevicePublicKey == null) {
+            throw new IllegalStateException("PQC device public key is missing.");
+        }
+        return pqcDevicePublicKey;
     }
 
     /**
@@ -357,10 +362,7 @@ public class ResultStatusObject {
      */
     @JsonIgnore
     public SecretKey getBiometryFactorKeyObject() {
-        final String biometryFactorKey = (String) jsonObject.get("biometryFactorKey");
-        if (biometryFactorKey == null) {
-            return null;
-        }
+        final String biometryFactorKey = getBiometryFactorKey();
         return KEY_CONVERTOR_EC.convertBytesToSharedSecretKey(Base64.getDecoder().decode(biometryFactorKey));
     }
 
@@ -380,7 +382,11 @@ public class ResultStatusObject {
      * @return Base64 encoded byte representation of the biometry factor key
      */
     public String getBiometryFactorKey() {
-        return (String) jsonObject.get("biometryFactorKey");
+        final String biometryFactorKey = (String) jsonObject.get("biometryFactorKey");
+        if (biometryFactorKey == null) {
+            throw new IllegalStateException("Biometry factor key is missing.");
+        }
+        return biometryFactorKey;
     }
 
     /**
@@ -396,7 +402,7 @@ public class ResultStatusObject {
      */
     @JsonIgnore
     public byte[] getKnowledgeFactorKeyEncryptedBytes() {
-        final String knowledgeFactorKeyEncrypted = (String) jsonObject.get("knowledgeFactorKeyEncrypted");
+        final String knowledgeFactorKeyEncrypted = getKnowledgeFactorKeyEncrypted();
         return Base64.getDecoder().decode(knowledgeFactorKeyEncrypted);
     }
 
@@ -414,7 +420,11 @@ public class ResultStatusObject {
      * @return Base64 encoded byte representation of the knowledge factor key
      */
     public String getKnowledgeFactorKeyEncrypted() {
-        return (String) jsonObject.get("knowledgeFactorKeyEncrypted");
+        final String knowledgeFactorKeyEncrypted = (String) jsonObject.get("knowledgeFactorKeyEncrypted");
+        if (knowledgeFactorKeyEncrypted == null) {
+            throw new IllegalStateException("Encrypted knowledge factor key is missing.");
+        }
+        return knowledgeFactorKeyEncrypted;
     }
 
     /**
@@ -430,7 +440,7 @@ public class ResultStatusObject {
      */
     @JsonIgnore
     public byte[] getKnowledgeFactorKeySaltBytes() {
-        final String knowledgeFactorKeySalt = (String) jsonObject.get("knowledgeFactorKeySalt");
+        final String knowledgeFactorKeySalt = getKnowledgeFactorKeySalt();
         return Base64.getDecoder().decode(knowledgeFactorKeySalt);
     }
 
@@ -448,7 +458,11 @@ public class ResultStatusObject {
      * @return Knowledge factor salt
      */
     public String getKnowledgeFactorKeySalt() {
-        return (String) jsonObject.get("knowledgeFactorKeySalt");
+        final String knowledgeFactorKeySalt = (String) jsonObject.get("knowledgeFactorKeySalt");
+        if (knowledgeFactorKeySalt == null) {
+            throw new IllegalStateException("Knowledge factor key salt is missing.");
+        }
+        return knowledgeFactorKeySalt;
     }
 
     /**
@@ -464,10 +478,7 @@ public class ResultStatusObject {
      */
     @JsonIgnore
     public SecretKey getPossessionFactorKeyObject() {
-        final String possessionFactorKey = (String) jsonObject.get("possessionFactorKey");
-        if (possessionFactorKey == null) {
-            return null;
-        }
+        final String possessionFactorKey = getPossessionFactorKey();
         return KEY_CONVERTOR_EC.convertBytesToSharedSecretKey(Base64.getDecoder().decode(possessionFactorKey));
     }
 
@@ -485,7 +496,11 @@ public class ResultStatusObject {
      * @return Base64 encoded byte representation of the possession factor key
      */
     public String getPossessionFactorKey() {
-        return (String) jsonObject.get("possessionFactorKey");
+        final String possessionFactorKey = (String) jsonObject.get("possessionFactorKey");
+        if (possessionFactorKey == null) {
+            throw new IllegalStateException("Possession factor key is missing.");
+        }
+        return possessionFactorKey;
     }
 
     /**
@@ -501,10 +516,7 @@ public class ResultStatusObject {
      */
     @JsonIgnore
     public SecretKey getTransportMasterKeyObject() {
-        final String transportMasterKey = (String) jsonObject.get("transportMasterKey");
-        if (transportMasterKey == null) {
-            return null;
-        }
+        final String transportMasterKey = getTransportMasterKey();
         return KEY_CONVERTOR_EC.convertBytesToSharedSecretKey(Base64.getDecoder().decode(transportMasterKey));
     }
 
@@ -514,7 +526,7 @@ public class ResultStatusObject {
      */
     @JsonIgnore
     public void setTransportMasterKeyObject(SecretKey transportMasterKeyObject) {
-        String transportMasterKey = Base64.getEncoder().encodeToString(KEY_CONVERTOR_EC.convertSharedSecretKeyToBytes(transportMasterKeyObject));
+        final String transportMasterKey = Base64.getEncoder().encodeToString(KEY_CONVERTOR_EC.convertSharedSecretKeyToBytes(transportMasterKeyObject));
         jsonObject.put("transportMasterKey", transportMasterKey);
     }
 
@@ -522,7 +534,11 @@ public class ResultStatusObject {
      * @return Base64 encoded byte representation of the transport master key (V3)
      */
     public String getTransportMasterKey() {
-        return (String) jsonObject.get("transportMasterKey");
+        final String transportMasterKey = (String) jsonObject.get("transportMasterKey");
+        if (transportMasterKey == null) {
+            throw new IllegalStateException("Transport master key is missing.");
+        }
+        return transportMasterKey;
     }
 
     /**
@@ -537,7 +553,11 @@ public class ResultStatusObject {
      * @return Shared secret algorithm (V4)
      */
     public String getSharedSecretAlgorithm() {
-        return (String) jsonObject.get("sharedSecretAlgorithm");
+        final String sharedSecretAlgorithm = (String) jsonObject.get("sharedSecretAlgorithm");
+        if (sharedSecretAlgorithm == null) {
+            throw new IllegalStateException("Shared secret algorithm is missing.");
+        }
+        return sharedSecretAlgorithm;
     }
 
     /**
@@ -554,9 +574,6 @@ public class ResultStatusObject {
     @JsonIgnore
     public SecretKey getTemporaryKeyActSignRequestKeyObject() {
         final String temporaryKeyActSignRequestKey = getTemporaryKeyActSignRequestKey();
-        if (temporaryKeyActSignRequestKey == null) {
-            return null;
-        }
         return KEY_CONVERTOR_EC.convertBytesToSharedSecretKey(Base64.getDecoder().decode(temporaryKeyActSignRequestKey));
     }
 
@@ -564,7 +581,11 @@ public class ResultStatusObject {
      * @return Key for signing payload in getting temporary key request in activation scope (V4)
      */
     public String getTemporaryKeyActSignRequestKey() {
-        return (String) jsonObject.get("temporaryKeyActSignRequestKey");
+        final String temporaryKeyActSignRequestKey = (String) jsonObject.get("temporaryKeyActSignRequestKey");
+        if (temporaryKeyActSignRequestKey == null) {
+            throw new IllegalStateException("Temporary key signing key is missing.");
+        }
+        return temporaryKeyActSignRequestKey;
     }
 
     /**
@@ -573,7 +594,7 @@ public class ResultStatusObject {
      */
     @JsonIgnore
     public void setTemporaryKeyActSignRequestKeyObject(SecretKey temporaryKeyActSignRequestKey) {
-        String temporaryKeyActSignRequestKeyBase64 = Base64.getEncoder().encodeToString(KEY_CONVERTOR_EC.convertSharedSecretKeyToBytes(temporaryKeyActSignRequestKey));
+        final String temporaryKeyActSignRequestKeyBase64 = Base64.getEncoder().encodeToString(KEY_CONVERTOR_EC.convertSharedSecretKeyToBytes(temporaryKeyActSignRequestKey));
         jsonObject.put("temporaryKeyActSignRequestKey", temporaryKeyActSignRequestKeyBase64);
     }
 
@@ -586,14 +607,11 @@ public class ResultStatusObject {
     }
 
     /**
-     * @return Key for for verifying MAC for status blob (V4)
+     * @return Key for verifying MAC for status blob (V4)
      */
     @JsonIgnore
     public SecretKey getStatusBlobMacKeyObject() {
         final String statusBlobMacKey = getStatusBlobMacKey();
-        if (statusBlobMacKey == null) {
-            return null;
-        }
         return KEY_CONVERTOR_EC.convertBytesToSharedSecretKey(Base64.getDecoder().decode(statusBlobMacKey));
     }
 
@@ -601,7 +619,11 @@ public class ResultStatusObject {
      * @return Key for verifying MAC for status blob (V4)
      */
     public String getStatusBlobMacKey() {
-        return (String) jsonObject.get("statusBlobMacKey");
+        final String statusBlobMacKey = (String) jsonObject.get("statusBlobMacKey");
+        if (statusBlobMacKey == null) {
+            throw new IllegalStateException("Status blob MAC key is missing.");
+        }
+        return statusBlobMacKey;
     }
 
     /**
@@ -610,13 +632,13 @@ public class ResultStatusObject {
      */
     @JsonIgnore
     public void setStatusBlobMacKeyObject(SecretKey statusBlobMacKey) {
-        String statusBlobMacKeyBase64 = Base64.getEncoder().encodeToString(KEY_CONVERTOR_EC.convertSharedSecretKeyToBytes(statusBlobMacKey));
+        final String statusBlobMacKeyBase64 = Base64.getEncoder().encodeToString(KEY_CONVERTOR_EC.convertSharedSecretKeyToBytes(statusBlobMacKey));
         jsonObject.put("statusBlobMacKey", statusBlobMacKeyBase64);
     }
 
     /**
      * Sets key for verifying MAC for status blob
-     * @param statusBlobMacKey Key for key for verifying MAC for status blob
+     * @param statusBlobMacKey Key for verifying MAC for status blob
      */
     public void setStatusBlobMacKey(String statusBlobMacKey) {
         jsonObject.put("statusBlobMacKey", statusBlobMacKey);
@@ -628,9 +650,6 @@ public class ResultStatusObject {
     @JsonIgnore
     public SecretKey getSharedInfo2KeyObject() {
         final String sharedInfo2Key = getSharedInfo2Key();
-        if (sharedInfo2Key == null) {
-            return null;
-        }
         return KEY_CONVERTOR_EC.convertBytesToSharedSecretKey(Base64.getDecoder().decode(sharedInfo2Key));
     }
 
@@ -638,7 +657,11 @@ public class ResultStatusObject {
      * @return Key for sharedInfo2 calculation for end-to-end encryption (V4)
      */
     public String getSharedInfo2Key() {
-        return (String) jsonObject.get("sharedInfo2Key");
+        final String sharedInfo2Key = (String) jsonObject.get("sharedInfo2Key");
+        if (sharedInfo2Key == null) {
+            throw new IllegalStateException("SharedInfo2 key is missing.");
+        }
+        return sharedInfo2Key;
     }
 
     /**
@@ -647,7 +670,7 @@ public class ResultStatusObject {
      */
     @JsonIgnore
     public void setSharedInfo2KeyObject(SecretKey sharedInfo2Key) {
-        String sharedInfo2KeyBase64 = Base64.getEncoder().encodeToString(KEY_CONVERTOR_EC.convertSharedSecretKeyToBytes(sharedInfo2Key));
+        final String sharedInfo2KeyBase64 = Base64.getEncoder().encodeToString(KEY_CONVERTOR_EC.convertSharedSecretKeyToBytes(sharedInfo2Key));
         jsonObject.put("sharedInfo2Key", sharedInfo2KeyBase64);
     }
 
@@ -660,37 +683,38 @@ public class ResultStatusObject {
     }
 
     /**
-     * @return Key for personalized data used in offline code tags (V4)
+     * @return Key for personalized data used in offline code MAC (V4)
      */
     @JsonIgnore
     public SecretKey getMacPersonalizedDataKeyObject() {
-        final String getMacPersonalizedDataKey = getMacPersonalizedDataKey();
-        if (getMacPersonalizedDataKey == null) {
-            return null;
-        }
-        return KEY_CONVERTOR_EC.convertBytesToSharedSecretKey(Base64.getDecoder().decode(getMacPersonalizedDataKey));
+        final String macPersonalizedDataKey = getMacPersonalizedDataKey();
+        return KEY_CONVERTOR_EC.convertBytesToSharedSecretKey(Base64.getDecoder().decode(macPersonalizedDataKey));
     }
 
     /**
-     * @return Key for personalized data used in offline code tags (V4)
+     * @return Key for personalized data used in offline code MAC (V4)
      */
     public String getMacPersonalizedDataKey() {
-        return (String) jsonObject.get("macPersonalizedDataKey");
+        final String macPersonalizedDataKey = (String) jsonObject.get("macPersonalizedDataKey");
+        if (macPersonalizedDataKey == null) {
+            throw new IllegalStateException("Offline personalized data MAC key is missing.");
+        }
+        return macPersonalizedDataKey;
     }
 
     /**
-     * Sets key for personalized data used in offline code tags (V4)
-     * @param macPersonalizedDataKey Key for personalized data used in offline code tags
+     * Sets key for personalized data used in offline code MAC (V4)
+     * @param macPersonalizedDataKey Key for personalized data used in offline code MAC
      */
     @JsonIgnore
     public void setMacPersonalizedDataKeyObject(SecretKey macPersonalizedDataKey) {
-        String macPersonalizedDataKeyBase64 = Base64.getEncoder().encodeToString(KEY_CONVERTOR_EC.convertSharedSecretKeyToBytes(macPersonalizedDataKey));
+        final String macPersonalizedDataKeyBase64 = Base64.getEncoder().encodeToString(KEY_CONVERTOR_EC.convertSharedSecretKeyToBytes(macPersonalizedDataKey));
         jsonObject.put("macPersonalizedDataKey", macPersonalizedDataKeyBase64);
     }
 
     /**
-     * Sets key for personalized data used in offline code tags (V4)
-     * @param macPersonalizedDataKey Key for personalized data used in offline code tags
+     * Sets key for personalized data used in offline code MAC (V4)
+     * @param macPersonalizedDataKey Key for personalized data used in offline code MAC
      */
     public void setMacPersonalizedDataKey(String macPersonalizedDataKey) {
         jsonObject.put("macPersonalizedDataKey", macPersonalizedDataKey);

--- a/powerauth-java-cmd-lib/src/main/java/com/wultra/security/powerauth/lib/cmd/steps/pojo/ResultStatusObject.java
+++ b/powerauth-java-cmd-lib/src/main/java/com/wultra/security/powerauth/lib/cmd/steps/pojo/ResultStatusObject.java
@@ -111,8 +111,11 @@ public class ResultStatusObject {
      */
     @JsonIgnore
     public byte[] getEncryptedEcDevicePrivateKeyBytes() {
-        final String encryptedDevicePrivateKey = getEncryptedEcDevicePrivateKey();
-        return Base64.getDecoder().decode(encryptedDevicePrivateKey);
+        final String encryptedEcDevicePrivateKey = getEncryptedEcDevicePrivateKey();
+        if (encryptedEcDevicePrivateKey == null) {
+            throw new IllegalStateException("Encrypted EC device private key is missing.");
+        }
+        return Base64.getDecoder().decode(encryptedEcDevicePrivateKey);
     }
 
     /**
@@ -129,11 +132,7 @@ public class ResultStatusObject {
      * @return Base64 encoded byte representation of the encrypted EC device private key
      */
     public String getEncryptedEcDevicePrivateKey() {
-        final String encryptedEcDevicePrivateKey = (String) jsonObject.get("encryptedEcDevicePrivateKey");
-        if (encryptedEcDevicePrivateKey == null) {
-            throw new IllegalStateException("Encrypted EC device private key is missing.");
-        }
-        return encryptedEcDevicePrivateKey;
+        return (String) jsonObject.get("encryptedEcDevicePrivateKey");
     }
 
     /**
@@ -149,8 +148,11 @@ public class ResultStatusObject {
      */
     @JsonIgnore
     public byte[] getEncryptedPqcDevicePrivateKeyBytes() {
-        final String encryptedDevicePrivateKey = getEncryptedPqcDevicePrivateKey();
-        return Base64.getDecoder().decode(encryptedDevicePrivateKey);
+        final String encryptedPqcDevicePrivateKey = getEncryptedPqcDevicePrivateKey();
+        if (encryptedPqcDevicePrivateKey == null) {
+            throw new IllegalStateException("Encrypted PQC device private key is missing.");
+        }
+        return Base64.getDecoder().decode(encryptedPqcDevicePrivateKey);
     }
 
     /**
@@ -167,11 +169,7 @@ public class ResultStatusObject {
      * @return Base64 encoded byte representation of the encrypted EC device private key
      */
     public String getEncryptedPqcDevicePrivateKey() {
-        final String encryptedPqcDevicePrivateKey = (String) jsonObject.get("encryptedPqcDevicePrivateKey");
-        if (encryptedPqcDevicePrivateKey == null) {
-            throw new IllegalStateException("Encrypted PQC device private key is missing.");
-        }
-        return encryptedPqcDevicePrivateKey;
+        return (String) jsonObject.get("encryptedPqcDevicePrivateKey");
     }
 
     /**
@@ -203,8 +201,11 @@ public class ResultStatusObject {
      */
     @JsonIgnore
     public PublicKey getEcServerPublicKeyObject() throws Exception {
-        final String serverPublicKey = getEcServerPublicKey();
-        return KEY_CONVERTOR_EC.convertBytesToPublicKey(resolveEcCurve(), Base64.getDecoder().decode(serverPublicKey));
+        final String ecServerPublicKey = getEcServerPublicKey();
+        if (ecServerPublicKey == null) {
+            throw new IllegalStateException("EC server public key is missing.");
+        }
+        return KEY_CONVERTOR_EC.convertBytesToPublicKey(resolveEcCurve(), Base64.getDecoder().decode(ecServerPublicKey));
     }
 
     /**
@@ -222,11 +223,7 @@ public class ResultStatusObject {
      * @return Base64 encoded byte representation of the EC server public key
      */
     public String getEcServerPublicKey() {
-        final String ecServerPublicKey = (String) jsonObject.get("ecServerPublicKey");
-        if (ecServerPublicKey == null) {
-            throw new IllegalStateException("EC server public key is missing.");
-        }
-        return ecServerPublicKey;
+        return (String) jsonObject.get("ecServerPublicKey");
     }
 
     /**
@@ -244,6 +241,9 @@ public class ResultStatusObject {
     @JsonIgnore
     public PublicKey getPqcServerPublicKeyObject() throws Exception {
         final String pqcServerPublicKey = getPqcServerPublicKey();
+        if (pqcServerPublicKey == null) {
+            throw new IllegalStateException("PQC server public key is missing.");
+        }
         return KEY_CONVERTOR_PQC_DSA.convertBytesToPublicKey(Base64.getDecoder().decode(pqcServerPublicKey));
     }
 
@@ -262,11 +262,7 @@ public class ResultStatusObject {
      * @return Base64 encoded byte representation of the PQC server public key
      */
     public String getPqcServerPublicKey() {
-        final String pqcServerPublicKey = (String) jsonObject.get("pqcServerPublicKey");
-        if (pqcServerPublicKey == null) {
-            throw new IllegalStateException("PQC server public key is missing.");
-        }
-        return pqcServerPublicKey;
+        return (String) jsonObject.get("pqcServerPublicKey");
     }
 
     /**
@@ -284,6 +280,9 @@ public class ResultStatusObject {
     @JsonIgnore
     public PublicKey getEcDevicePublicKeyObject() throws Exception {
         final String ecDevicePublicKey = getEcDevicePublicKey();
+        if (ecDevicePublicKey == null) {
+            throw new IllegalStateException("EC device public key is missing.");
+        }
         return KEY_CONVERTOR_EC.convertBytesToPublicKey(resolveEcCurve(), Base64.getDecoder().decode(ecDevicePublicKey));
     }
 
@@ -302,11 +301,7 @@ public class ResultStatusObject {
      * @return Base64 encoded byte representation of the EC device public key
      */
     public String getEcDevicePublicKey() {
-        final String ecDevicePublicKey = (String) jsonObject.get("ecDevicePublicKey");
-        if (ecDevicePublicKey == null) {
-            throw new IllegalStateException("EC device public key is missing.");
-        }
-        return ecDevicePublicKey;
+        return (String) jsonObject.get("ecDevicePublicKey");
     }
 
     /**
@@ -324,6 +319,9 @@ public class ResultStatusObject {
     @JsonIgnore
     public PublicKey getPqcDevicePublicKeyObject() throws Exception {
         final String pqcDevicePublicKey = getPqcDevicePublicKey();
+        if (pqcDevicePublicKey == null) {
+            throw new IllegalStateException("PQC device public key is missing.");
+        }
         return KEY_CONVERTOR_PQC_DSA.convertBytesToPublicKey(Base64.getDecoder().decode(pqcDevicePublicKey));
     }
 
@@ -342,11 +340,7 @@ public class ResultStatusObject {
      * @return Base64 encoded byte representation of the PQC device public key
      */
     public String getPqcDevicePublicKey() {
-        final String pqcDevicePublicKey = (String) jsonObject.get("pqcDevicePublicKey");
-        if (pqcDevicePublicKey == null) {
-            throw new IllegalStateException("PQC device public key is missing.");
-        }
-        return pqcDevicePublicKey;
+        return (String) jsonObject.get("pqcDevicePublicKey");
     }
 
     /**
@@ -363,6 +357,9 @@ public class ResultStatusObject {
     @JsonIgnore
     public SecretKey getBiometryFactorKeyObject() {
         final String biometryFactorKey = getBiometryFactorKey();
+        if (biometryFactorKey == null) {
+            throw new IllegalStateException("Biometry factor key is missing.");
+        }
         return KEY_CONVERTOR_EC.convertBytesToSharedSecretKey(Base64.getDecoder().decode(biometryFactorKey));
     }
 
@@ -382,11 +379,7 @@ public class ResultStatusObject {
      * @return Base64 encoded byte representation of the biometry factor key
      */
     public String getBiometryFactorKey() {
-        final String biometryFactorKey = (String) jsonObject.get("biometryFactorKey");
-        if (biometryFactorKey == null) {
-            throw new IllegalStateException("Biometry factor key is missing.");
-        }
-        return biometryFactorKey;
+        return (String) jsonObject.get("biometryFactorKey");
     }
 
     /**
@@ -403,6 +396,9 @@ public class ResultStatusObject {
     @JsonIgnore
     public byte[] getKnowledgeFactorKeyEncryptedBytes() {
         final String knowledgeFactorKeyEncrypted = getKnowledgeFactorKeyEncrypted();
+        if (knowledgeFactorKeyEncrypted == null) {
+            throw new IllegalStateException("Encrypted knowledge factor key is missing.");
+        }
         return Base64.getDecoder().decode(knowledgeFactorKeyEncrypted);
     }
 
@@ -420,11 +416,7 @@ public class ResultStatusObject {
      * @return Base64 encoded byte representation of the knowledge factor key
      */
     public String getKnowledgeFactorKeyEncrypted() {
-        final String knowledgeFactorKeyEncrypted = (String) jsonObject.get("knowledgeFactorKeyEncrypted");
-        if (knowledgeFactorKeyEncrypted == null) {
-            throw new IllegalStateException("Encrypted knowledge factor key is missing.");
-        }
-        return knowledgeFactorKeyEncrypted;
+        return (String) jsonObject.get("knowledgeFactorKeyEncrypted");
     }
 
     /**
@@ -441,6 +433,9 @@ public class ResultStatusObject {
     @JsonIgnore
     public byte[] getKnowledgeFactorKeySaltBytes() {
         final String knowledgeFactorKeySalt = getKnowledgeFactorKeySalt();
+        if (knowledgeFactorKeySalt == null) {
+            throw new IllegalStateException("Knowledge factor key salt is missing.");
+        }
         return Base64.getDecoder().decode(knowledgeFactorKeySalt);
     }
 
@@ -458,11 +453,7 @@ public class ResultStatusObject {
      * @return Knowledge factor salt
      */
     public String getKnowledgeFactorKeySalt() {
-        final String knowledgeFactorKeySalt = (String) jsonObject.get("knowledgeFactorKeySalt");
-        if (knowledgeFactorKeySalt == null) {
-            throw new IllegalStateException("Knowledge factor key salt is missing.");
-        }
-        return knowledgeFactorKeySalt;
+        return (String) jsonObject.get("knowledgeFactorKeySalt");
     }
 
     /**
@@ -489,6 +480,9 @@ public class ResultStatusObject {
     @JsonIgnore
     public void setPossessionFactorKeyObject(SecretKey possessionFactorKeyObject) {
         final String possessionFactorKey = Base64.getEncoder().encodeToString(KEY_CONVERTOR_EC.convertSharedSecretKeyToBytes(possessionFactorKeyObject));
+        if (possessionFactorKey == null) {
+            throw new IllegalStateException("Possession factor key is missing.");
+        }
         jsonObject.put("possessionFactorKey", possessionFactorKey);
     }
 
@@ -496,11 +490,7 @@ public class ResultStatusObject {
      * @return Base64 encoded byte representation of the possession factor key
      */
     public String getPossessionFactorKey() {
-        final String possessionFactorKey = (String) jsonObject.get("possessionFactorKey");
-        if (possessionFactorKey == null) {
-            throw new IllegalStateException("Possession factor key is missing.");
-        }
-        return possessionFactorKey;
+        return (String) jsonObject.get("possessionFactorKey");
     }
 
     /**
@@ -517,6 +507,9 @@ public class ResultStatusObject {
     @JsonIgnore
     public SecretKey getTransportMasterKeyObject() {
         final String transportMasterKey = getTransportMasterKey();
+        if (transportMasterKey == null) {
+            throw new IllegalStateException("Transport master key is missing.");
+        }
         return KEY_CONVERTOR_EC.convertBytesToSharedSecretKey(Base64.getDecoder().decode(transportMasterKey));
     }
 
@@ -534,11 +527,7 @@ public class ResultStatusObject {
      * @return Base64 encoded byte representation of the transport master key (V3)
      */
     public String getTransportMasterKey() {
-        final String transportMasterKey = (String) jsonObject.get("transportMasterKey");
-        if (transportMasterKey == null) {
-            throw new IllegalStateException("Transport master key is missing.");
-        }
-        return transportMasterKey;
+        return (String) jsonObject.get("transportMasterKey");
     }
 
     /**
@@ -553,11 +542,7 @@ public class ResultStatusObject {
      * @return Shared secret algorithm (V4)
      */
     public String getSharedSecretAlgorithm() {
-        final String sharedSecretAlgorithm = (String) jsonObject.get("sharedSecretAlgorithm");
-        if (sharedSecretAlgorithm == null) {
-            throw new IllegalStateException("Shared secret algorithm is missing.");
-        }
-        return sharedSecretAlgorithm;
+        return (String) jsonObject.get("sharedSecretAlgorithm");
     }
 
     /**
@@ -574,6 +559,9 @@ public class ResultStatusObject {
     @JsonIgnore
     public SecretKey getTemporaryKeyActSignRequestKeyObject() {
         final String temporaryKeyActSignRequestKey = getTemporaryKeyActSignRequestKey();
+        if (temporaryKeyActSignRequestKey == null) {
+            throw new IllegalStateException("Temporary key signing key is missing.");
+        }
         return KEY_CONVERTOR_EC.convertBytesToSharedSecretKey(Base64.getDecoder().decode(temporaryKeyActSignRequestKey));
     }
 
@@ -581,11 +569,7 @@ public class ResultStatusObject {
      * @return Key for signing payload in getting temporary key request in activation scope (V4)
      */
     public String getTemporaryKeyActSignRequestKey() {
-        final String temporaryKeyActSignRequestKey = (String) jsonObject.get("temporaryKeyActSignRequestKey");
-        if (temporaryKeyActSignRequestKey == null) {
-            throw new IllegalStateException("Temporary key signing key is missing.");
-        }
-        return temporaryKeyActSignRequestKey;
+        return (String) jsonObject.get("temporaryKeyActSignRequestKey");
     }
 
     /**
@@ -612,6 +596,9 @@ public class ResultStatusObject {
     @JsonIgnore
     public SecretKey getStatusBlobMacKeyObject() {
         final String statusBlobMacKey = getStatusBlobMacKey();
+        if (statusBlobMacKey == null) {
+            throw new IllegalStateException("Status blob MAC key is missing.");
+        }
         return KEY_CONVERTOR_EC.convertBytesToSharedSecretKey(Base64.getDecoder().decode(statusBlobMacKey));
     }
 
@@ -619,11 +606,7 @@ public class ResultStatusObject {
      * @return Key for verifying MAC for status blob (V4)
      */
     public String getStatusBlobMacKey() {
-        final String statusBlobMacKey = (String) jsonObject.get("statusBlobMacKey");
-        if (statusBlobMacKey == null) {
-            throw new IllegalStateException("Status blob MAC key is missing.");
-        }
-        return statusBlobMacKey;
+        return (String) jsonObject.get("statusBlobMacKey");
     }
 
     /**
@@ -650,6 +633,9 @@ public class ResultStatusObject {
     @JsonIgnore
     public SecretKey getSharedInfo2KeyObject() {
         final String sharedInfo2Key = getSharedInfo2Key();
+        if (sharedInfo2Key == null) {
+            throw new IllegalStateException("SharedInfo2 key is missing.");
+        }
         return KEY_CONVERTOR_EC.convertBytesToSharedSecretKey(Base64.getDecoder().decode(sharedInfo2Key));
     }
 
@@ -657,11 +643,7 @@ public class ResultStatusObject {
      * @return Key for sharedInfo2 calculation for end-to-end encryption (V4)
      */
     public String getSharedInfo2Key() {
-        final String sharedInfo2Key = (String) jsonObject.get("sharedInfo2Key");
-        if (sharedInfo2Key == null) {
-            throw new IllegalStateException("SharedInfo2 key is missing.");
-        }
-        return sharedInfo2Key;
+        return (String) jsonObject.get("sharedInfo2Key");
     }
 
     /**
@@ -688,6 +670,9 @@ public class ResultStatusObject {
     @JsonIgnore
     public SecretKey getMacPersonalizedDataKeyObject() {
         final String macPersonalizedDataKey = getMacPersonalizedDataKey();
+        if (macPersonalizedDataKey == null) {
+            throw new IllegalStateException("Offline personalized data MAC key is missing.");
+        }
         return KEY_CONVERTOR_EC.convertBytesToSharedSecretKey(Base64.getDecoder().decode(macPersonalizedDataKey));
     }
 
@@ -695,11 +680,7 @@ public class ResultStatusObject {
      * @return Key for personalized data used in offline code MAC (V4)
      */
     public String getMacPersonalizedDataKey() {
-        final String macPersonalizedDataKey = (String) jsonObject.get("macPersonalizedDataKey");
-        if (macPersonalizedDataKey == null) {
-            throw new IllegalStateException("Offline personalized data MAC key is missing.");
-        }
-        return macPersonalizedDataKey;
+        return (String) jsonObject.get("macPersonalizedDataKey");
     }
 
     /**

--- a/powerauth-java-cmd-lib/src/main/java/com/wultra/security/powerauth/lib/cmd/steps/pojo/ResultStatusObject.java
+++ b/powerauth-java-cmd-lib/src/main/java/com/wultra/security/powerauth/lib/cmd/steps/pojo/ResultStatusObject.java
@@ -358,7 +358,7 @@ public class ResultStatusObject {
     public SecretKey getBiometryFactorKeyObject() {
         final String biometryFactorKey = getBiometryFactorKey();
         if (biometryFactorKey == null) {
-            throw new IllegalStateException("Biometry factor key is missing.");
+            return null;
         }
         return KEY_CONVERTOR_EC.convertBytesToSharedSecretKey(Base64.getDecoder().decode(biometryFactorKey));
     }

--- a/powerauth-java-cmd-lib/src/main/java/com/wultra/security/powerauth/lib/cmd/util/TemporaryKeyUtil.java
+++ b/powerauth-java-cmd-lib/src/main/java/com/wultra/security/powerauth/lib/cmd/util/TemporaryKeyUtil.java
@@ -170,9 +170,6 @@ public class TemporaryKeyUtil {
                 case APPLICATION_SCOPE -> appSecretBytes;
                 case ACTIVATION_SCOPE -> {
                     final SecretKey transportMasterKey = model.getResultStatus().getTransportMasterKeyObject();
-                    if (transportMasterKey == null) {
-                        throw new IllegalStateException("The transportMasterKey is missing");
-                    }
                     final SecretKey secretKeyBytes = KEY_GENERATOR.deriveSecretKeyHmac(transportMasterKey, appSecretBytes);
                     yield KEY_CONVERTOR.convertSharedSecretKeyToBytes(secretKeyBytes);
                 }


### PR DESCRIPTION
Improved validation of result status model for keys which should be present when requested.