### PR TITLE
Fix #646: Update default shared secret algorithm

### DIFF
--- a/powerauth-java-cmd-lib/src/main/java/com/wultra/security/powerauth/lib/cmd/util/SecurityUtil.java
+++ b/powerauth-java-cmd-lib/src/main/java/com/wultra/security/powerauth/lib/cmd/util/SecurityUtil.java
@@ -143,7 +143,7 @@ public class SecurityUtil {
     public static SharedSecretAlgorithm getDefaultSharedSecretAlgorithm(PowerAuthVersion version) {
         return switch (version.getMajorVersion()) {
             case 3 -> SharedSecretAlgorithm.EC_P256;
-            case 4 -> SharedSecretAlgorithm.EC_P384_ML_L5;
+            case 4 -> SharedSecretAlgorithm.EC_P384_ML_L3;
             default -> throw new IllegalArgumentException("Unsupported version: " + version);
         };
     }


### PR DESCRIPTION
I suggest to keep the `EC_P384_ML_L3` as the default for consistency with the SDK.