### PR TITLE
Fix #653: Missing metadata for Sonatype (forward-port)

### DIFF
--- a/powerauth-java-cmd-lib/pom.xml
+++ b/powerauth-java-cmd-lib/pom.xml
@@ -5,6 +5,7 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>powerauth-java-cmd-lib</artifactId>
+    <name>powerauth-java-cmd-lib</name>
     <description>PowerAuth Command-line Utility - Java Library</description>
 
     <parent>


### PR DESCRIPTION
(cherry picked from commit ee3d558d91d2e8d639bbc2d8e6b8a3eeb19c482b)